### PR TITLE
Pin version of WeasyPrint and CairoSVG.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-weasyprint
+weasyprint==0.27
+CairoSVG==1.0.20


### PR DESCRIPTION
It appears CairoSVG 2.0rc1 was recently released and doesn't build correctly.

Fixes #21 