### PR TITLE
Integrate Ballot 183

### DIFF
--- a/docs/Bylaws.md
+++ b/docs/Bylaws.md
@@ -3,7 +3,7 @@
 
 **BYLAWS OF THE CA/BROWSER FORUM** 
 
-**Version 1.3 - Adopted effective as of 10 July 2015**
+**Version 1.4 - Adopted effective as of 4 April 2016**
 
 \_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
 
@@ -69,8 +69,10 @@ The Chair will read an antitrust compliance statement at the start of all Forum 
 CA Applicants should supply the following additional information:
  
 (6) URL of the current qualifying performance audit report.
+
+(7) The URL of at least one third party website that includes a certificate issued by the Applicant in the certificate chain.
  
-(7) Links or references to issued certificates that demonstrate compliance with all applicable certificate, CRL, and OCSP requirements.
+(8) Links or references to issued certificates that demonstrate compliance with all applicable certificate, CRL, and OCSP requirements.
 
 
 (c)        An Applicant shall become a Member once the Forum has determined by consensus among the Members during a teleconference or meeting that the Applicant meets all of the requirements of subsection (a) or, upon the request of any Member, by a Ballot among the Members.  Acceptance by consensus shall be determined or a Ballot of Members shall be held as soon as the Applicant indicates that it has presented all information required under subsection (b) and has responded to all follow-up questions from the Forum and the Member has complied with the requirements of Section 5.5.

--- a/docs/Bylaws.md
+++ b/docs/Bylaws.md
@@ -3,7 +3,7 @@
 
 **BYLAWS OF THE CA/BROWSER FORUM** 
 
-**Version 1.4 - Adopted effective as of 4 April 2016**
+**Version 1.5 - Adopted effective as of 31 January 2017**
 
 \_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
 
@@ -77,25 +77,59 @@ CA Applicants should supply the following additional information:
 
 (c)        An Applicant shall become a Member once the Forum has determined by consensus among the Members during a teleconference or meeting that the Applicant meets all of the requirements of subsection (a) or, upon the request of any Member, by a Ballot among the Members.  Acceptance by consensus shall be determined or a Ballot of Members shall be held as soon as the Applicant indicates that it has presented all information required under subsection (b) and has responded to all follow-up questions from the Forum and the Member has complied with the requirements of Section 5.5.
 
-**2.2        Ballots Among Forum Members**
+**2.2        General Provisions Applicable to all Ballots**
 
-Ballots will be conducted in accordance with the following rules.
+The following rules will apply to all ballots, including Draft Guideline Ballots (defined in Section 2.3).
 
 (a)        Only votes by Members shall be accepted.
 
 (b)        Only one vote per Member company shall be accepted; representatives of corporate affiliates shall not vote.
 
-(c)        A representative of any Member can call for a proposed ballot to be published for review and comment by the membership. Any proposed ballot needs two endorsements by other Members in order to proceed. The review period then shall take place for at least seven calendar-days before votes are cast.
+(c)        A representative of any Member can call for a proposed ballot to be published for discussion and comment by the membership. Any proposed ballot needs two endorsements by other Members in order to proceed. The discussion period then shall take place for at least seven but no more than 14 calendar days before votes are cast.  The proposer of the ballot will designate the length of the discussion period, and each ballot shall clearly state the start and end dates and times (including time zone) for both the discussion period and the voting period.
 
-(d)        The CA/Browser Forum shall provide seven calendar-days for voting, with the deadline clearly communicated via the members' electronic mailing list. All voting will take place online via the members' electronic mailing list.
+(d)        Upon completion of the discussion period, Members shall have exactly seven calendar days for voting, with the deadline clearly communicated in the ballot and sent via the Public Mail List. All voting will take place via the Public Mail List.   Votes not submitted to the Public Mail List will not be considered valid, and will not be counted for any purpose.
 
-(e)        Only votes that indicate a clear 'yes' or 'no' response to the ballot question shall be considered (i.e. votes to abstain and votes that do not indicate a clear 'yes' or 'no' response will not figure in the calculation of item (f), below).
+(e)        Members may vote yes, no, or abstain on a ballot.  Only votes that indicate a clear ‘yes’ or ‘no’ response to the ballot question shall be considered (i.e. votes to abstain and votes that do not indicate a clear ‘yes’ or ‘no’ response will not figure in the calculation of item (f), below).
 
-(f)        Members fall into two categories: CAs (comprising issuing CAs and root CAs, as defined in the membership criteria) and product suppliers (as defined in the membership criteria). In order for the motion to be adopted by the Forum, two-thirds or more of the votes cast by the Members in the CA category must be in favor of the motion, and at least 50% plus one of the votes cast by the members in the browser category must be in favor of the motion  At least one CA Member and one browser Member must vote in favor of a ballot for the ballot to be adopted.
+(f)        Members fall into two categories: CAs (comprising issuing CAs and root CAs, as defined in the membership criteria) and browsers (as defined in the membership criteria). In order for the ballot to be adopted by the Forum, two-thirds or more of the votes cast by the Members in the CA category must be in favor of the ballot, and at least 50% plus one of the votes cast by the members in the browser category must be in favor of the ballot. At least one CA Member and one browser Member must vote in favor of a ballot for the ballot to be adopted.
 
-(g)        A ballot result will be considered valid only when more than half of the number of currently active members has participated. The number of currently active members is the average number of member organizations that have participated in the previous three meetings (both teleconferences and face-to-face meetings).
+(g)        A ballot result will be considered valid only when more than half of the number of currently active Members has participated. The number of currently active Members is the average number of Member organizations that have participated in the previous three Forum-wide meetings (both teleconferences and face-to-face meetings).  Working Group, subgroup, committee, PAG, and other similar meetings do not count for purposes of calculating the “number of currently active members.”
 
-(h)        The CA/Browser Forum will tabulate and announce the results within one calendar-day of the close of the voting period.
+(h)        The Chair will tabulate and announce the results within 3 business days of the close of the voting period.
+
+(i)        The Chair may delegate any of his/her duties under this Section 2.2 and Section 2.3 to the Vice Chair as necessary, or the Vice Chair may otherwise execute the duties and obligations of the Chair as provided in Section 4.1(a) of these Bylaws.
+
+**2.2        Requirements for Draft Guideline Ballots**
+
+This section applies to any ballot that proposes a Final Guideline or a Final Maintenance Guideline (a “Draft Guideline Ballot”), all as defined under the Forum’s IPR Policy.  Draft Guideline Ballots must comply with the following rules in addition to the requirements set forth in Section 2.2 above.
+
+(a)        A Draft Guideline Ballot will clearly indicate whether it is proposing a Final Guideline or a Final Maintenance Guideline.  If the Draft Guideline Ballot is proposing a Final Guideline, such ballot will include the full text of the Draft Guideline intended to become a Final Guideline.  If the Draft Guideline Ballot is proposing a Final Maintenance Guideline, such ballot will include a redline or comparison showing the set of changes from the Final Guideline section(s) intended to become a Final Maintenance Guideline, and need not include a copy of the full set of guidelines.  Such redline or comparison shall be made against the Final Guideline section(s) as they exist at the time a ballot is proposed, and need not take into consideration other ballots that may be proposed subsequently, except as provided in Section 2.3(j) below.
+
+(b)        As described in Section 2.2(c), there will be a discussion period of at least seven but no more than 14 calendar days before votes are cast on a Draft Guideline Ballot, with the start and end dates of such discussion period clearly specified in the ballot.
+
+(c)        As described in Section 2.2(d), upon completion of such discussion period, Members shall have exactly seven calendar days to vote on a Draft Guideline Ballot, with the deadline clearly communicated in the ballot sent via the Public Mail List. All voting will take place via the Public Mail List.  Votes not submitted to the Public Mail List will not be considered valid, and will not be counted for any purpose.  The Chair may send an email to the Public Mail List reminding Members of when the voting period opens and closes.
+
+(d)        The Forum (via the Chair) will tabulate and announce the results within 3 business days of the close of the initial voting period (the “Initial Vote”).  If the Draft Guidelines Ballot does not pass the Initial Vote, the ballot will stop.
+
+(e)        If a Draft Guideline Ballot passes the Initial Vote, the Chair shall initiate, no later than the 3rd business day after the announcement of the Initial Vote results, the Review Period of 30 or 60 days, as applicable and as described in Section 4.1 of the IPR Policy.  The Chair will initiate the Review Period by sending the Review Notice to both the Member Mail List and the Public Mail List.  The Review Notice will clearly specify the open and close dates and times (with time zone) of the Review Period.  If the Chair does not initiate the Review Period within 5 business days after the announcement of the Initial Vote results, the Vice Chair may initiate the Review Period, using the same process as the Chair would have been required to use.
+
+(f)        The Review Period will continue to the end of the 30- or 60-day period, as applicable, regardless of the number of Exclusion Notices filed pursuant to the IPR Policy during such period, if any.  No later than 3 business days after the conclusion of the applicable Review Period, the Chair will distribute any Exclusion Notices submitted in accordance with Section 4.2 of the IPR Policy via the Public Mail List; provided, however, that the Chair may distribute such Exclusion Notices earlier.
+
+(g)        In addition to following the process for submitting Exclusion Notices set forth in Section 4 of the IPR Policy, Members will also send Exclusion Notices to the Public Mail List as a safeguard.
+
+(h)        If no Exclusion Notices are filed during the Review Period with respect to a Draft Guideline Ballot, then the results of the Initial Vote are automatically deemed to be final and approved, and Draft Guidelines then become either Final Guidelines or Final Maintenance Guidelines, as designated in the Draft Guidelines Ballot.  The Chair will notify both the Member Mail List and the Public Mail List of the final approval within 3 business days, as well as update the Public Website of Final Guidelines and Final Maintenance Guidelines within 10 business days of the close of the Review Period.
+
+(i)        If Exclusion Notice(s) are filed during the Review Period (as described in Section 4.3 of the IPR Policy), then the results of the Initial Vote are automatically rescinded and deemed null and void, and;
+
+(i)        A Patent Advisory Group (PAG) will be formed, in accordance with Section 7 of the IPR Policy, to address the conflict.  The PAG will make a conclusion as described in Section 7.3.2 of the IPR Policy, and communicate such conclusion to the rest of the Forum, using the Member Mail List and the Public Mail List.; and
+
+(ii)        After the PAG provides its conclusion, if the proposer and endorsers decide to proceed with the Draft Guidelines Ballot, and:
+
+(A)        The proposer and endorsers do not make any changes to the Draft Guidelines Ballot, such ballot must go through the steps described in Sections 2.3(b) through (d) above, replacing the “Initial Vote” with a “Second Vote.”  If a Draft Guidelines Ballot passes the Second Vote, then the results of the Second Vote are deemed to be final and approved.  Draft Guidelines then become either Final Guidelines or Final Maintenance Guidelines, as designated in the Draft Guidelines Ballot.  The Chair will notify both the Member Mail List and the Public Mail List of the approval, as well as update the public website of Final Guidelines and Final Maintenance Guidelines; or
+
+(B)        The proposer and endorsers make changes to the Draft Guidelines Ballot, a new Draft Guidelines Ballot must be proposed, and must go through the steps described in Sections 2.3(a) through (i) above.
+
+(j)        If a ballot is proposed to amend the same section of the Final Guidelines or the Final Maintenance Guidelines as one or more previous ballot(s) that has/have not yet been finally approved, the newly proposed ballot must include information about, and a link to, any such previous ballot(s), and may include provisions to avoid any conflicts relating to such previous ballots.
 
 **3.  OTHER FORUM PARTICIPATION**
 
@@ -240,6 +274,10 @@ The Forum procedure for dealing with questions and comments sent to the Question
 (d)        If no objections are received before the deadline expires, then send the response to the questioner.
 
 (e)        If consensus cannot be achieved, or one or more objections are received, then the matter should be dealt with in the next Forum Meeting or Forum Teleconference.
+
+**6.3        Interpretation of Bylaws**
+
+Nothing in these Bylaws is intended to supersede or replace anything in the IPR Policy. In the event of a conflict between these Bylaws and the IPR Policy, the IPR Policy shall govern.
 
 **DEFINITIONS**
 


### PR DESCRIPTION
This builds on https://github.com/cabforum/documents/pull/38 to include both that and the text of Ballot 183. I provided these as separate commits and PRs to make it easier to review from a process point

This integrates Ballot 183, passed at https://cabforum.org/2017/01/31/ballot-183-amending-bylaws-clarify-ballot-approval-process/ , and brings alignment to https://cabforum.org/wp-content/uploads/CA-Browser-Forum-Bylaws-v.-1.5.pdf