### PR TITLE
Offer a Docker quickstart option.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM buildpack-deps:jessie-scm
+RUN apt update
+RUN apt install -y \
+  bundler \
+  libcairo2 \
+  libffi-dev \
+  libgdk-pixbuf2.0-0 \
+  libpango1.0-0 \
+  libssl-dev \
+  python \
+  python-dev \
+  python-lxml \
+  python-pip \
+  python-virtualenv \
+  ruby \
+  shared-mime-info
+
+RUN mkdir /documents
+WORKDIR /documents
+# These two packages are too old in the Jessie repos, get newer ones. Setuptools
+# needs to be upgraded before we can install from requirements.txt.
+RUN pip install -U setuptools
+RUN pip install -U cffi
+COPY requirements.txt Gemfile Gemfile.lock /tmp/
+RUN pip install -r /tmp/requirements.txt
+RUN bundle install --gemfile /tmp/Gemfile

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,3 @@ PLATFORMS
 
 DEPENDENCIES
   kramdown
-
-BUNDLED WITH
-   1.10.5

--- a/README.md
+++ b/README.md
@@ -16,11 +16,26 @@ The HTML format is usable either in a browser or in Microsoft Word.
 
 # Building
 
-The build process involves generating HTML documents from Kramdown, then
+The build process involves generating HTML documents from kramdown, then
 generating PDF documents from HTML using [Weasyprint](http://weasyprint.org/).
+These have a number of other dependencies that can be time-consuming to install.
+The fastest way to start is to use a Docker image, which works on Windows and
+macOS, and Linux:
 
-You'll need ruby, bundler, Python, pip, gcc, and several libraries installed.
-See .travis.yml for a list of packages installable on Ubuntu. Make sure that
+    git clone https://github.com/cabforum/documents/
+    cd documents
+    docker run --rm --volume $PWD:/documents j4cob/cabforum make
+
+This will automatically download a Docker image containing the necessary
+dependencies, and run `make` in a container based off that image.
+The output will be available in the output/ directory. This docker command
+mounts the current directory as a volume, so it will build from the version of
+the documents in the current directory. You can edit files on the Docker host,
+and use Docker just for building.
+
+If you want to install the dependencies without Docker, you'll need ruby,
+bundler, Python, pip, gcc, and several libraries installed.
+See Dockerfile for a list of packages installable on Debian. Make sure that
 ~/.local/bin/ is in your $PATH.
 
 Install kramdown and weasyprint via bundler and pip, respectively:
@@ -37,3 +52,12 @@ make
 ```
 
 The output is available in the output/ directory.
+
+# Building the Docker image locally
+
+If you'd like to build a copy of the Docker image locally, for instance, to use
+a different version of Weasyprint or kramdown, run:
+
+    docker build --tag my_cabforum_tag .
+    docker run --rm --volume $PWD:/documents my_cabforum_tag make
+

--- a/utils/kram.rb
+++ b/utils/kram.rb
@@ -34,7 +34,7 @@ if ARGV.count == 2
 	options[:output] = ARGV[1]
 end
 
-s = File.read(options[:input])
+s = File.read(options[:input], :encoding => 'utf-8')
 
 kram_opts = {:entity_output => :symbolic}
 if options.has_key? :template


### PR DESCRIPTION
The dependencies to run Weasyprint and kramdown are somewhat tricky to install.
This Dockerfile codifies how to build a Docker image from them. I've also
provided a pre-built Docker image at https://hub.docker.com/r/j4cob/cabforum/.

Update the README to describe how to use the Docker image, and fix
Kramdown->kramdown per https://kramdown.gettalong.org/.

Specify an explicit encoding in kram.rb to avoid errors about non-US-ASCII
characters in Markdown input.