### PR TITLE
Fix title if 7.1.4.1 per ballot 146

### DIFF
--- a/docs/BR.md
+++ b/docs/BR.md
@@ -1639,7 +1639,7 @@ Effective 16 January 2015, CAs SHOULD NOT issue Subscriber Certificates utilizin
 
 ### 7.1.4 Name Forms
 
-#### 7.1.4.1 Issuing CA Certificate Subject
+#### 7.1.4.1 Issuer Information
 The content of the Certificate Issuer Distinguished Name field MUST match the Subject DN of the Issuing CA to support Name chaining as specified in RFC 5280, section 4.1.2.4.
 
 #### 7.1.4.2 Subject Information - Subscriber Certificates


### PR DESCRIPTION
Section 7.1.4.1 should be listed as "Issuer Information". This was a typo introduced in https://github.com/cabforum/documents/commit/661505addb9c5a0e9f35bcbc98f0629e26c3842d#diff-84a0a987677aabc0ae38abb27f95fb6d, related to Ballot 146 - https://cabforum.org/2015/04/16/ballot-146-convert-baseline-requirements-to-rfc-3647-framework/.