### PR TITLE
SC30 - Disclosure of Registration/Incorporating Agency

### DIFF
--- a/docs/EVG.md
+++ b/docs/EVG.md
@@ -346,6 +346,12 @@ Each CA MUST publicly disclose its Certificate Policy and/or Certification Pract
 
 Effective as of 31 May 2018, the CA's Certificate Policy and/or Certification Practice Statement MUST be structured in accordance with RFC 3647. Prior to 31 May 2018, the CA's Certificate Policy and/or Certification Practice Statement MUST be structured in accordance with either RFC 2527 or RFC 3647. The Certificate Policy and/or Certification Practice Statement MUST include all material required by RFC 3647 or, if structured as such, RFC 2527.
 
+Effective as of 1 September 2020, the CA MUST publicly disclose through an appropriate and readily accessible online means that is available on a 24x7 basis every Incorporating Agency and Registration Agency it has determined satisfies the requirements in these Guidelines. The CA SHALL document where to obtain this information within Section 3.2 of the CA's Certificate Policy and/or Certification Practice Statement. This Agency Information SHALL include the following:
+* Sufficient information to unambiguously identify the Incorporating Agency or Registration Agency (such as a name, jurisdiction, and website); and,
+* The accepted values for the `subject:jurisdictionLocalityName` (OID: 1.3.6.1.4.1.311.60.2.1.1), `subject:jurisdictionStateOrProvinceName` (OID: 1.3.6.1.4.1.311.60.2.1.2), and `subject:jursidictionCountryName` (OID: 1.3.6.1.4.1.311.60.2.1.3) fields when a certificate is issued using information from that Incorporating Agency or Registration Agency, indicating the jurisidction(s) that the Agency is appropriate for; and,
+* The accepted or allowed form or syntax of the Registration Number used by the Incorporating Agency or Registration Agency, if known; and,
+* A revision history that includes a unique version number and date of publication for any additions, modifications, or removals from this list.
+
 ## 8.3.  Commitment to Comply with Recommendations
 
 Each CA SHALL publicly give effect to these Guidelines and represent that they will adhere to the latest published version by incorporating them into their respective EV Policies, using a clause such as the following (which must include a link to the official version of these Guidelines):
@@ -490,6 +496,8 @@ Country:
 
 **Contents:**    These fields MUST NOT contain information that is not relevant to the level of the Incorporating Agency or Registration Agency.  For example, the Jurisdiction of Incorporation for an Incorporating Agency or Jurisdiction of Registration for a Registration Agency that operates at the country level MUST include the country information but MUST NOT include the state or province or locality information.  Similarly, the jurisdiction for the applicable Incorporating Agency or Registration Agency at the state or province level MUST include both country and state or province information, but MUST NOT include locality information.  And, the jurisdiction for the applicable Incorporating Agency or Registration Agency at the locality level MUST include the country and state or province information, where the state or province regulates the registration of the entities at the locality level, as well as the locality information.  Country information MUST be specified using the applicable ISO country code.  State or province or locality information (where applicable) for the Subject's Jurisdiction of Incorporation or Registration MUST be specified using the full name of the applicable jurisdiction.
 
+Effective as of 1 September 2020, the CA SHALL ensure that the information to be included is consistent with its publicly-available disclosure, as described in Section 8.2.2.
+
 ### 9.2.5.  Subject Registration Number Field
 
 **Certificate field:**    _subject:serialNumber_ (OID:  2.5.4.5)
@@ -501,6 +509,8 @@ Country:
 For Government Entities that do not have a Registration Number or readily verifiable date of creation, the CA SHALL enter appropriate language to indicate that the Subject is a Government Entity.
 
 For Business Entities, the Registration Number that was received by the Business Entity upon government registration SHALL be entered in this field.  For those Business Entities that register with an Incorporating Agency or Registration Agency in a jurisdiction that does not issue numbers pursuant to government registration, the date of the registration SHALL be entered into this field in any one of the common date formats.
+
+Effective as of 1 Setember 2020, the CA SHALL ensure that the format of any Registration Number that is included is consistent with the publicly-available disclosure for that Registration Agency or Incorporating Agency, as described in Section 8.2.2.
 
 ### 9.2.6.  Subject Physical Address of Place of Business Field
 

--- a/docs/EVG.md
+++ b/docs/EVG.md
@@ -491,7 +491,7 @@ Country:
 
 **Contents:**    These fields MUST NOT contain information that is not relevant to the level of the Incorporating Agency or Registration Agency.  For example, the Jurisdiction of Incorporation for an Incorporating Agency or Jurisdiction of Registration for a Registration Agency that operates at the country level MUST include the country information but MUST NOT include the state or province or locality information.  Similarly, the jurisdiction for the applicable Incorporating Agency or Registration Agency at the state or province level MUST include both country and state or province information, but MUST NOT include locality information.  And, the jurisdiction for the applicable Incorporating Agency or Registration Agency at the locality level MUST include the country and state or province information, where the state or province regulates the registration of the entities at the locality level, as well as the locality information.  Country information MUST be specified using the applicable ISO country code.  State or province or locality information (where applicable) for the Subject's Jurisdiction of Incorporation or Registration MUST be specified using the full name of the applicable jurisdiction.
 
-Effective as of 1 October 2020, the CA SHALL ensure that the information to be included is consistent with its publicly-available disclosure, as described in Section 11.1.3.
+Effective as of 1 October 2020, the CA SHALL ensure that, at time of issuance, the values within these fields have been disclosed within the latest publicly-available disclosure, as described in Section 11.1.3, as acceptable values for the applicable Incorporating Agency or Registration Agency.
 
 ### 9.2.5.  Subject Registration Number Field
 
@@ -505,7 +505,7 @@ For Government Entities that do not have a Registration Number or readily verifi
 
 For Business Entities, the Registration Number that was received by the Business Entity upon government registration SHALL be entered in this field.  For those Business Entities that register with an Incorporating Agency or Registration Agency in a jurisdiction that does not issue numbers pursuant to government registration, the date of the registration SHALL be entered into this field in any one of the common date formats.
 
-Effective as of 1 October 2020, the CA SHALL ensure that the format of any Registration Number that is included is consistent with the publicly-available disclosure for that Registration Agency or Incorporating Agency, as described in Section 11.1.3.
+Effective as of 1 October 2020, the CA SHALL ensure that, at time of issuance, if the CA has disclosed a set of acceptable format or formats for Registration Numbers for the applicable Registration Agency or Incorporating Agency, as described in Section 11.1.3, that the Registration Number is valid according to at least one disclosed format for that applicable Registration Agency or Incorporating agency. 
 
 ### 9.2.6.  Subject Physical Address of Place of Business Field
 

--- a/docs/EVG.md
+++ b/docs/EVG.md
@@ -505,7 +505,7 @@ For Government Entities that do not have a Registration Number or readily verifi
 
 For Business Entities, the Registration Number that was received by the Business Entity upon government registration SHALL be entered in this field.  For those Business Entities that register with an Incorporating Agency or Registration Agency in a jurisdiction that does not issue numbers pursuant to government registration, the date of the registration SHALL be entered into this field in any one of the common date formats.
 
-Effective as of 1 October 2020, the CA SHALL ensure that, at time of issuance, if the CA has disclosed a set of acceptable format or formats for Registration Numbers for the applicable Registration Agency or Incorporating Agency, as described in Section 11.1.3, that the Registration Number is valid according to at least one disclosed format for that applicable Registration Agency or Incorporating agency. 
+Effective as of 1 October 2020, if the CA has disclosed a set of acceptable format or formats for Registration Numbers for the applicable Registration Agency or Incorporating Agency, as described in Section 11.1.3, the CA MUST ensure, prior to issuance, that the Registration Number is valid according to at least one currently disclosed format for that applicable Registration Agency or Incorporating agency. 
 
 ### 9.2.6.  Subject Physical Address of Place of Business Field
 
@@ -757,15 +757,15 @@ As a general rule, the CA is responsible for taking all verification steps reaso
 
 ### 11.1.3.  Disclosure of Verification Sources
 
-Effective as of 1 October 2020, prior to the use of an Incorporating Agency or Registration Agency to fulfill these verification requirements, the CA MUST publicly disclose, through an appropriate and readily accessible online means, Agency Information about the Incorporating Agency or Registration Agency.
+Effective as of 1 October 2020, prior to the use of an Incorporating Agency or Registration Agency to fulfill these verification requirements, the CA MUST publicly disclose Agency Information about the Incorporating Agency or Registration Agency. This disclosure SHALL be through an appropriate and readily accessible online means.
 
 This Agency Information SHALL include at least the following:
 * Sufficient information to unambiguously identify the Incorporating Agency or Registration Agency (such as a name, jurisdiction, and website); and,
 * The accepted value or values for each of the `subject:jurisdictionLocalityName` (OID: 1.3.6.1.4.1.311.60.2.1.1), `subject:jurisdictionStateOrProvinceName` (OID: 1.3.6.1.4.1.311.60.2.1.2), and `subject:jursidictionCountryName` (OID: 1.3.6.1.4.1.311.60.2.1.3) fields, when a certificate is issued using information from that Incorporating Agency or Registration Agency, indicating the jurisdiction(s) that the Agency is appropriate for; and,
-* If the CA restricts the form or syntax of the Registration Number used by the Incorporating Agency or Registration Agency, then the acceptable forms or syntax of such Numbers; and,
+* The acceptable form or syntax of Registration Numbers used by the Incorporating Agency or Registration Agency, if the CA restricts such Numbers to an acceptable form or syntax; and,
 * A revision history that includes a unique version number and date of publication for any additions, modifications, and/or removals from this list.
 
-The CA SHALL document where to obtain this information within Section 3.2 of the CA's Certificate Policy and/or Certification Practice Statement.
+The CA MUST document where to obtain this information within Section 3.2 of the CA's Certificate Policy and/or Certification Practice Statement.
 
 ## 11.2.  Verification of Applicant's Legal Existence and Identity
 

--- a/docs/EVG.md
+++ b/docs/EVG.md
@@ -761,7 +761,7 @@ Effective as of 1 October 2020, prior to the use of an Incorporating Agency or R
 
 This Agency Information SHALL include at least the following:
 * Sufficient information to unambiguously identify the Incorporating Agency or Registration Agency (such as a name, jurisdiction, and website); and,
-* The accepted values for the `subject:jurisdictionLocalityName` (OID: 1.3.6.1.4.1.311.60.2.1.1), `subject:jurisdictionStateOrProvinceName` (OID: 1.3.6.1.4.1.311.60.2.1.2), and `subject:jursidictionCountryName` (OID: 1.3.6.1.4.1.311.60.2.1.3) fields when a certificate is issued using information from that Incorporating Agency or Registration Agency, indicating the jurisidction(s) that the Agency is appropriate for; and,
+* The accepted value or values for each of the `subject:jurisdictionLocalityName` (OID: 1.3.6.1.4.1.311.60.2.1.1), `subject:jurisdictionStateOrProvinceName` (OID: 1.3.6.1.4.1.311.60.2.1.2), and `subject:jursidictionCountryName` (OID: 1.3.6.1.4.1.311.60.2.1.3) fields, when a certificate is issued using information from that Incorporating Agency or Registration Agency, indicating the jurisidction(s) that the Agency is appropriate for; and,
 * If the CA restricts the form or syntax of the Registration Number used by the Incorporating Agency or Registration Agency, then the acceptable forms or syntax of such Numbers; and,
 * A revision history that includes a unique version number and date of publication for any additions, modifications, or removals from this list.
 

--- a/docs/EVG.md
+++ b/docs/EVG.md
@@ -762,7 +762,7 @@ Effective as of 1 October 2020, prior to the use of an Incorporating Agency or R
 This Agency Information SHALL include at least the following:
 * Sufficient information to unambiguously identify the Incorporating Agency or Registration Agency (such as a name, jurisdiction, and website); and,
 * The accepted values for the `subject:jurisdictionLocalityName` (OID: 1.3.6.1.4.1.311.60.2.1.1), `subject:jurisdictionStateOrProvinceName` (OID: 1.3.6.1.4.1.311.60.2.1.2), and `subject:jursidictionCountryName` (OID: 1.3.6.1.4.1.311.60.2.1.3) fields when a certificate is issued using information from that Incorporating Agency or Registration Agency, indicating the jurisidction(s) that the Agency is appropriate for; and,
-* The accepted or allowed form or syntax of the Registration Number used by the Incorporating Agency or Registration Agency, if known; and,
+* If the CA restricts the form or syntax of the Registration Number used by the Incorporating Agency or Registration Agency, then the acceptable forms or syntax of such Numbers; and,
 * A revision history that includes a unique version number and date of publication for any additions, modifications, or removals from this list.
 
 The CA SHALL document where to obtain this information within Section 3.2 of the CA's Certificate Policy and/or Certification Practice Statement.

--- a/docs/EVG.md
+++ b/docs/EVG.md
@@ -763,7 +763,7 @@ This Agency Information SHALL include at least the following:
 * Sufficient information to unambiguously identify the Incorporating Agency or Registration Agency (such as a name, jurisdiction, and website); and,
 * The accepted value or values for each of the `subject:jurisdictionLocalityName` (OID: 1.3.6.1.4.1.311.60.2.1.1), `subject:jurisdictionStateOrProvinceName` (OID: 1.3.6.1.4.1.311.60.2.1.2), and `subject:jursidictionCountryName` (OID: 1.3.6.1.4.1.311.60.2.1.3) fields, when a certificate is issued using information from that Incorporating Agency or Registration Agency, indicating the jurisdiction(s) that the Agency is appropriate for; and,
 * If the CA restricts the form or syntax of the Registration Number used by the Incorporating Agency or Registration Agency, then the acceptable forms or syntax of such Numbers; and,
-* A revision history that includes a unique version number and date of publication for any additions, modifications, or removals from this list.
+* A revision history that includes a unique version number and date of publication for any additions, modifications, and/or removals from this list.
 
 The CA SHALL document where to obtain this information within Section 3.2 of the CA's Certificate Policy and/or Certification Practice Statement.
 

--- a/docs/EVG.md
+++ b/docs/EVG.md
@@ -83,6 +83,7 @@ The CA/Browser Forum is a voluntary open organization of certification authoriti
 | **Compliance** | **Section(s)** | **Summary Description (See Full Text for Details)** |
 | --- | --- | --- |
 | 2020-01-31 | 9.2.8 | If subject:organizationIdentifier is present, the Subject Organization Identifier Extension MUST be present |
+| 2020-10-1 | 11.1.3 | Prior to using an Incorporating Agency or Registration Agency, the CA MUST ensure the agency has been publicly disclosed |
 
 **Implementers' Note:**  Version 1.3 of these EV Guidelines was published on 20 November 2010 and supplemented through May 2012 when version 1.4 was published.  ETSI TS 102 042 and ETSI TR 101 564 Technical Report: Guidance on ETSI TS 102 042 for Issuing Extended Validation Certificates for Auditors and CSPs reference version 1.3 of these EV Guidelines, and ETSI Draft EN 319 411-1 references version 1.4.  Version 1.4.5 of Webtrust(r) for Certification Authorities – Extended Validation Audit Criteria references version 1.4.5 of these EV Guidelines.  As illustrated in the Document History table above, the CA/Browser Forum continues to improve relevant industry guidelines, including this document, the Baseline Requirements, and the Network and Certificate System Security Requirements.  We encourage all CAs to conform to each revision on the date specified without awaiting a corresponding update to an applicable audit criterion.  In the event of a conflict between an existing audit criterion and a guideline revision, we will communicate with the audit community and attempt to resolve any uncertainty. We will respond to implementation questions directed to questions@cabforum.org.  Our coordination with compliance auditors will continue as we develop guideline revision cycles that harmonize with the revision cycles for audit criteria, the compliance auditing periods and cycles of CAs, and the CA/Browser Forum's guideline implementation dates.
 
@@ -346,12 +347,6 @@ Each CA MUST publicly disclose its Certificate Policy and/or Certification Pract
 
 Effective as of 31 May 2018, the CA's Certificate Policy and/or Certification Practice Statement MUST be structured in accordance with RFC 3647. Prior to 31 May 2018, the CA's Certificate Policy and/or Certification Practice Statement MUST be structured in accordance with either RFC 2527 or RFC 3647. The Certificate Policy and/or Certification Practice Statement MUST include all material required by RFC 3647 or, if structured as such, RFC 2527.
 
-Effective as of 1 September 2020, the CA MUST publicly disclose through an appropriate and readily accessible online means that is available on a 24x7 basis every Incorporating Agency and Registration Agency it has determined satisfies the requirements in these Guidelines. The CA SHALL document where to obtain this information within Section 3.2 of the CA's Certificate Policy and/or Certification Practice Statement. This Agency Information SHALL include the following:
-* Sufficient information to unambiguously identify the Incorporating Agency or Registration Agency (such as a name, jurisdiction, and website); and,
-* The accepted values for the `subject:jurisdictionLocalityName` (OID: 1.3.6.1.4.1.311.60.2.1.1), `subject:jurisdictionStateOrProvinceName` (OID: 1.3.6.1.4.1.311.60.2.1.2), and `subject:jursidictionCountryName` (OID: 1.3.6.1.4.1.311.60.2.1.3) fields when a certificate is issued using information from that Incorporating Agency or Registration Agency, indicating the jurisidction(s) that the Agency is appropriate for; and,
-* The accepted or allowed form or syntax of the Registration Number used by the Incorporating Agency or Registration Agency, if known; and,
-* A revision history that includes a unique version number and date of publication for any additions, modifications, or removals from this list.
-
 ## 8.3.  Commitment to Comply with Recommendations
 
 Each CA SHALL publicly give effect to these Guidelines and represent that they will adhere to the latest published version by incorporating them into their respective EV Policies, using a clause such as the following (which must include a link to the official version of these Guidelines):
@@ -496,7 +491,7 @@ Country:
 
 **Contents:**    These fields MUST NOT contain information that is not relevant to the level of the Incorporating Agency or Registration Agency.  For example, the Jurisdiction of Incorporation for an Incorporating Agency or Jurisdiction of Registration for a Registration Agency that operates at the country level MUST include the country information but MUST NOT include the state or province or locality information.  Similarly, the jurisdiction for the applicable Incorporating Agency or Registration Agency at the state or province level MUST include both country and state or province information, but MUST NOT include locality information.  And, the jurisdiction for the applicable Incorporating Agency or Registration Agency at the locality level MUST include the country and state or province information, where the state or province regulates the registration of the entities at the locality level, as well as the locality information.  Country information MUST be specified using the applicable ISO country code.  State or province or locality information (where applicable) for the Subject's Jurisdiction of Incorporation or Registration MUST be specified using the full name of the applicable jurisdiction.
 
-Effective as of 1 September 2020, the CA SHALL ensure that the information to be included is consistent with its publicly-available disclosure, as described in Section 8.2.2.
+Effective as of 1 October 2020, the CA SHALL ensure that the information to be included is consistent with its publicly-available disclosure, as described in Section 11.1.3.
 
 ### 9.2.5.  Subject Registration Number Field
 
@@ -510,7 +505,7 @@ For Government Entities that do not have a Registration Number or readily verifi
 
 For Business Entities, the Registration Number that was received by the Business Entity upon government registration SHALL be entered in this field.  For those Business Entities that register with an Incorporating Agency or Registration Agency in a jurisdiction that does not issue numbers pursuant to government registration, the date of the registration SHALL be entered into this field in any one of the common date formats.
 
-Effective as of 1 Setember 2020, the CA SHALL ensure that the format of any Registration Number that is included is consistent with the publicly-available disclosure for that Registration Agency or Incorporating Agency, as described in Section 8.2.2.
+Effective as of 1 October 2020, the CA SHALL ensure that the format of any Registration Number that is included is consistent with the publicly-available disclosure for that Registration Agency or Incorporating Agency, as described in Section 11.1.3.
 
 ### 9.2.6.  Subject Physical Address of Place of Business Field
 
@@ -759,6 +754,18 @@ Before issuing an EV Certificate, the CA MUST ensure that all Subject organizati
 ###  11.1.2.  Acceptable Methods of Verification – Overview
 
 As a general rule, the CA is responsible for taking all verification steps reasonably necessary to satisfy each of the Verification Requirements set forth in the subsections below.  The Acceptable Methods of Verification set forth in each of Sections 11.2 through 11.14 (which usually include alternatives) are considered to be the minimum acceptable level of verification required of the CA.  In all cases, however, the CA is responsible for taking any additional verification steps that may be reasonably necessary under the circumstances to satisfy the applicable Verification Requirement.
+
+### 11.1.3.  Disclosure of Verification Sources
+
+Effective as of 1 October 2020, prior to the use of an Incorporating Agency or Registration Agency to fulfill these verification requirements, the CA MUST publicly disclose, through an appropriate and readily accessible online means, Agency Information about the Incorporating Agency or Registration Agency.
+
+This Agency Information SHALL include at least the following:
+* Sufficient information to unambiguously identify the Incorporating Agency or Registration Agency (such as a name, jurisdiction, and website); and,
+* The accepted values for the `subject:jurisdictionLocalityName` (OID: 1.3.6.1.4.1.311.60.2.1.1), `subject:jurisdictionStateOrProvinceName` (OID: 1.3.6.1.4.1.311.60.2.1.2), and `subject:jursidictionCountryName` (OID: 1.3.6.1.4.1.311.60.2.1.3) fields when a certificate is issued using information from that Incorporating Agency or Registration Agency, indicating the jurisidction(s) that the Agency is appropriate for; and,
+* The accepted or allowed form or syntax of the Registration Number used by the Incorporating Agency or Registration Agency, if known; and,
+* A revision history that includes a unique version number and date of publication for any additions, modifications, or removals from this list.
+
+The CA SHALL document where to obtain this information within Section 3.2 of the CA's Certificate Policy and/or Certification Practice Statement.
 
 ## 11.2.  Verification of Applicant's Legal Existence and Identity
 

--- a/docs/EVG.md
+++ b/docs/EVG.md
@@ -761,7 +761,7 @@ Effective as of 1 October 2020, prior to the use of an Incorporating Agency or R
 
 This Agency Information SHALL include at least the following:
 * Sufficient information to unambiguously identify the Incorporating Agency or Registration Agency (such as a name, jurisdiction, and website); and,
-* The accepted value or values for each of the `subject:jurisdictionLocalityName` (OID: 1.3.6.1.4.1.311.60.2.1.1), `subject:jurisdictionStateOrProvinceName` (OID: 1.3.6.1.4.1.311.60.2.1.2), and `subject:jursidictionCountryName` (OID: 1.3.6.1.4.1.311.60.2.1.3) fields, when a certificate is issued using information from that Incorporating Agency or Registration Agency, indicating the jurisidction(s) that the Agency is appropriate for; and,
+* The accepted value or values for each of the `subject:jurisdictionLocalityName` (OID: 1.3.6.1.4.1.311.60.2.1.1), `subject:jurisdictionStateOrProvinceName` (OID: 1.3.6.1.4.1.311.60.2.1.2), and `subject:jursidictionCountryName` (OID: 1.3.6.1.4.1.311.60.2.1.3) fields, when a certificate is issued using information from that Incorporating Agency or Registration Agency, indicating the jurisdiction(s) that the Agency is appropriate for; and,
 * If the CA restricts the form or syntax of the Registration Number used by the Incorporating Agency or Registration Agency, then the acceptable forms or syntax of such Numbers; and,
 * A revision history that includes a unique version number and date of publication for any additions, modifications, or removals from this list.
 


### PR DESCRIPTION
# Purpose

The EV Guidelines aim to ensure a consistent and repeatable level of validation for certificates, regardless of the CA performing the validation, providing Relying Parties consistency for all certificates complying with these Guidelines. Although the Guidelines attempt to specify objective requirements, areas remain that rely on a subjective determination by the CA. One such area is determining whether a given Incorporating Agency or Registration Agency fulfills these Requirements. 

As currently specified, it's possible for one CA to make a determination that a given Registration Agency or Incorporating Agency does meet the requirements of the EV Guidelines, while a different CA determines that same Agency does not. As the reliability of the information validated within the Certificate is tied to the reliability of the data source used to verify this information, this inconsistency undermines the assurance that EV Certificates are meant to provide.

While there is utility in being able to identify precisely what datasource(s) were used with a given Certificate, this ballot does not involve such work. It merely seeks to ensure that, for any given Organization, it can be validated consistently and to the same degree, regardless of the CA, by working to achieve consistency among all CAs in their selection of data sources.

Much like the work to remove "Any other method" from the validation of domain names, ensuring consistency, transparency, and objectivity in validating domain names, this ballot is the first step to doing the same for organization information.

A potential roadmap of ballots to to address these issues involves:
* CAs publish the list of Registration Agencies / Incorporating Agencies they use (this ballot)
* Create an allowed list of Registration Agencies / Incorporating Agencies and associated values, along with a process for updating and adding new ones, and requiring issuance exclusively use Agencies on this list.
* If useful and relevant to Relying Parties, ensure each Certificate can be tied back to their Registration Agency / Incorporating Agency, such as disclosure within the Certificate itself, so they can unambiguously and uniquely determine the organization that has been validated.

A similar process may then be repeated for other forms of verification data sources, such as the QIIS, QTIS, and QGIS within the EV Guidelines, or the Reliable Data Sources within the Baseline Requirements.