### PR TITLE
SC35+SC28

### DIFF
--- a/docs/BR.md
+++ b/docs/BR.md
@@ -123,7 +123,7 @@ The following Certificate Policy identifiers are reserved for use by CAs as an o
 
 \* Effective Date and Additionally Relevant Compliance Date(s)
 
-### 1.2.2. Relevant Dates
+### 1.2.2 Relevant Dates
 
 | **Compliance** | **Section(s)** | **Summary Description (See Full Text for Details)** |
 |--|--|----------|
@@ -244,7 +244,9 @@ No stipulation.
 
 **Base Domain Name**: The portion of an applied-for FQDN that is the first domain name node left of a registry-controlled or public suffix plus the registry-controlled or public suffix (e.g. "example.co.uk" or "example.com"). For FQDNs where the right-most domain name node is a gTLD having ICANN Specification 13 in its registry agreement, the gTLD itself may be used as the Base Domain Name.
 
-**CAA**: From RFC 6844 (<http://tools.ietf.org/html/rfc6844>): "The Certification Authority Authorization (CAA) DNS Resource Record allows a DNS domain name holder to specify the Certification Authorities (CAs) authorized to issue certificates for that domain. Publication of CAA Resource Records allows a public Certification Authority to implement additional controls to reduce the risk of unintended certificate mis-issue."
+**CAA**: From RFC 8659 (<http://tools.ietf.org/html/rfc8659>): "The Certification Authority Authorization (CAA) DNS Resource Record allows a DNS domain name holder to specify one or more Certification Authorities (CAs) authorized to issue certificates for that domain name.  CAA Resource Records allow a public CA to implement additional controls to reduce the risk of unintended certificate mis-issue."
+
+**CA Key Pair**: A Key Pair where the Public Key appears as the Subject Public Key Info in one or more Root CA Certificate(s) and/or Subordinate CA Certificate(s).
 
 **Certificate**: An electronic document that uses a digital signature to bind a public key and an identity.
 
@@ -272,13 +274,13 @@ No stipulation.
 
 **Delegated Third Party**: A natural person or Legal Entity that is not the CA but is authorized by the CA, and whose activities are not within the scope of the appropriate CA audits, to assist in the Certificate Management Process by performing or fulfilling one or more of the CA requirements found herein.
 
-**DNS CAA Email Contact**: The email address defined in section B.1.1.
+**DNS CAA Email Contact**: The email address defined in Section A.1.1.
 
-**DNS CAA Phone Contact**: The phone number defined in section B.1.2.
+**DNS CAA Phone Contact**: The phone number defined in Section A.1.2.
 
-**DNS TXT Record Email Contact**: The email address defined in section B.2.1.
+**DNS TXT Record Email Contact**: The email address defined in Section A.2.1.
 
-**DNS TXT Record Phone Contact**: The phone number defined in section B.2.2.
+**DNS TXT Record Phone Contact**: The phone number defined in Section A.2.2.
 
 **Domain Authorization Document**: Documentation provided by, or a CA's documentation of a communication with, a Domain Name Registrar, the Domain Name Registrant, or the person or entity listed in WHOIS as the Domain Name Registrant (including any private, anonymous, or proxy registration service) attesting to the authority of an Applicant to request a Certificate for a specific Domain Namespace.
 
@@ -314,7 +316,7 @@ No stipulation.
 
 **Key Compromise**: A Private Key is said to be compromised if its value has been disclosed to an unauthorized person, or an unauthorized person has had access to it.
 
-**Key Generation Script**: A documented plan of procedures for the generation of a CA Key Pair **.**
+**Key Generation Script**: A documented plan of procedures for the generation of a CA Key Pair.
 
 **Key Pair**: The Private Key and its associated Public Key.
 
@@ -374,7 +376,7 @@ The binding SHALL use a digital signature algorithm or a cryptographic hash algo
   (iii) a hash of a PKCS#10 CSR.
 A Request Token may also be concatenated with a timestamp or other data. If a CA wanted to always use a hash of a PKCS#10 CSR as a Request Token and did not want to incorporate a timestamp and did want to allow certificate key re-use then the applicant might use the challenge password in the creation of a CSR with OpenSSL to ensure uniqueness even if the subject and key are identical between subsequent requests.
 
-**Note**: This simplistic shell command produces a Request Token which has a timestamp and a hash of a CSR. 
+**Note**: This simplistic shell command produces a Request Token which has a timestamp and a hash of a CSR.
   ``echo `date -u +%Y%m%d%H%M` `sha256sum <r2.csr` \| sed "s/[ -]//g"``
 The script outputs:
   201602251811c9c863405fe7675a3988b97664ea6baf442019e4e52fa335f406f7c5f26cf14f
@@ -492,7 +494,7 @@ RFC5019, Request for Comments: 5019, The Lightweight Online Certificate Status P
 
 RFC5280, Request for Comments: 5280, Internet X.509 Public Key Infrastructure: Certificate and Certificate Revocation List (CRL) Profile, Cooper et al, May 2008.
 
-RFC6844, Request for Comments: 6844, DNS Certification Authority Authorization (CAA) Resource Record, Hallam-Baker, Stradling, January 2013.
+RFC8659, Request for Comments: 8659, DNS Certification Authority Authorization (CAA) Resource Record, Hallam-Baker, Stradling, Hoffman-Andrews, November 2019.
 
 RFC6960, Request for Comments: 6960, X.509 Internet Public Key Infrastructure Online Certificate Status Protocol - OCSP. Santesson, Myers, Ankney, Malpani, Galperin, Adams, June 2013.
 
@@ -520,7 +522,7 @@ The CA SHALL publicly disclose its Certificate Policy and/or Certification Pract
 
 The Certificate Policy and/or Certification Practice Statement MUST be structured in accordance with RFC 3647 and MUST include all material required by RFC 3647.
 
-Section 4.2 of a CA's Certificate Policy and/or Certification Practice Statement SHALL state the CA's policy or practice on processing CAA Records for Fully Qualified Domain Names; that policy shall be consistent with these Requirements. It shall clearly specify the set of Issuer Domain Names that the CA recognises in CAA "issue" or "issuewild" records as permitting it to issue. The CA SHALL log all actions taken, if any, consistent with its processing practice.
+Section 4.2 of a CA's Certificate Policy and/or Certification Practice Statement SHALL state the CA's policy or practice on processing CAA Records for Fully Qualified Domain Names; that policy shall be consistent with these Requirements. It shall clearly specify the set of Issuer Domain Names that the CA recognizes in CAA "issue" or "issuewild" records as permitting it to issue. The CA SHALL log all actions taken, if any, consistent with its processing practice.
 
 The CA SHALL publicly give effect to these Requirements and represent that it will adhere to the latest published version. The CA MAY fulfill this requirement by incorporating these Requirements directly into its Certificate Policy and/or Certification Practice Statements or by incorporating them by reference using a clause such as the following (which MUST include a link to the official version of these Requirements):
 
@@ -588,7 +590,7 @@ This section defines the permitted processes and procedures for validating the A
 The CA SHALL confirm that prior to issuance, the CA has validated each Fully-Qualified Domain Name (FQDN) listed in the Certificate as follows:
 
 1.  When the FQDN does not contain "onion" as the rightmost label, the CA SHALL validate the FQDN using at least one of the methods listed below; and
-1.  When the FQDN contains "onion" as the rightmost label, the CA SHALL validate the FQDN in accordance with Appendix C.
+1.  When the FQDN contains "onion" as the rightmost label, the CA SHALL validate the FQDN in accordance with Appendix B.
 
 Completed validations of Applicant authority may be valid for the issuance of multiple Certificates over time. In all cases, the validation must have been initiated within the time period specified in the relevant requirement (such as Section 4.2.1 of this document) prior to Certificate issuance. For purposes of domain validation, the term Applicant includes the Applicant's Parent Company, Subsidiary Company, or Affiliate.
 
@@ -656,7 +658,7 @@ Confirming the Applicant's control over the FQDN by confirming one of the follow
 
 If a Random Value is used, the CA SHALL provide a Random Value unique to the Certificate request and SHALL not use the Random Value after the longer of (i) 30 days or (ii) if the Applicant submitted the Certificate request, the timeframe permitted for reuse of validated information relevant to the certificate (such as in Section 4.2.1 of these Guidelines or Section 11.14.3 of the EV Guidelines).
 
-CAs MUST NOT perform validation using this method after 3 months from the IPR review date of Ballot SC25. CAs MAY continue to re-use information and validations for domains validated under this method per the applicable certificate data reuse periods.
+CAs SHALL NOT perform validations using this method after June 3, 2020. CAs MAY continue to re-use information and validations for domains validated under this method per the applicable certificate data reuse periods.
 
 **Note:** Once the FQDN has been validated using this method, the CA MAY also issue Certificates for other FQDNs that end with all the labels of the validated FQDN.  This method is suitable for validating Wildcard Domain Names.
 
@@ -692,9 +694,9 @@ Confirming the Applicant's control over the FQDN by validating the Applicant is 
 
 **Note:** Once the FQDN has been validated using this method, the CA MAY also issue Certificates for other FQDNs that end with all the labels of the validated FQDN. This method is suitable for validating Wildcard Domain Names.
 
-##### 3.2.2.4.13: Email to DNS CAA Contact
+##### 3.2.2.4.13 Email to DNS CAA Contact
 
-Confirming the Applicant's control over the FQDN by sending a Random Value via email and then receiving a confirming response utilizing the Random Value. The Random Value MUST be sent to a DNS CAA Email Contact.  The relevant CAA Resource Record Set MUST be found using the search algorithm defined in RFC 6844 Section 4, as amended by Errata 5065 (Appendix A).
+Confirming the Applicant's control over the FQDN by sending a Random Value via email and then receiving a confirming response utilizing the Random Value. The Random Value MUST be sent to a DNS CAA Email Contact.  The relevant CAA Resource Record Set MUST be found using the search algorithm defined in RFC 8659, Section 3.
 
 Each email MAY confirm control of multiple FQDNs, provided that each email address is a DNS CAA Email Contact for each Authorization Domain Name being validated.  The same email MAY be sent to multiple recipients as long as all recipients are DNS CAA Email Contacts for each Authorization Domain Name being validated.
 
@@ -702,7 +704,7 @@ The Random Value SHALL be unique in each email. The email MAY be re-sent in its 
 
 **Note:** Once the FQDN has been validated using this method, the CA MAY also issue Certificates for other FQDNs that end with all the labels of the validated FQDN. This method is suitable for validating Wildcard Domain Names.
 
-##### 3.2.2.4.14: Email to DNS TXT Contact
+##### 3.2.2.4.14 Email to DNS TXT Contact
 
 Confirming the Applicant's control over the FQDN by sending a Random Value via email and then receiving a confirming response utilizing the Random Value. The Random Value MUST be sent to a DNS TXT Record Email Contact for the Authorization Domain Name selected to validate the FQDN.
 
@@ -737,7 +739,7 @@ The Random Value SHALL remain valid for use in a confirming response for no more
 **Note:** Once the FQDN has been validated using this method, the CA MAY also issue Certificates for other FQDNs that end with all the labels of the validated FQDN.  This method is suitable for validating Wildcard Domain Names.
 
 ##### 3.2.2.4.17 Phone Contact with DNS CAA Phone Contact
-Confirm the Applicant's control over the FQDN by calling the DNS CAA Phone Contact’s phone number and obtain a confirming response to validate the ADN. Each phone call MAY confirm control of multiple ADNs provided that the same DNS CAA Phone Contact phone number is listed for each ADN being verified and they provide a confirming response for each ADN. The relevant CAA Resource Record Set MUST be found using the search algorithm defined in RFC 6844 Section 4, as amended by Errata 5065 (Appendix A).
+Confirm the Applicant's control over the FQDN by calling the DNS CAA Phone Contact’s phone number and obtain a confirming response to validate the ADN. Each phone call MAY confirm control of multiple ADNs provided that the same DNS CAA Phone Contact phone number is listed for each ADN being verified and they provide a confirming response for each ADN. The relevant CAA Resource Record Set MUST be found using the search algorithm defined in RFC 8659 Section 3.
 
 The CA MUST NOT be transferred or request to be transferred as this phone number has been specifically listed for the purposes of Domain Validation.
 
@@ -747,13 +749,13 @@ The Random Value SHALL remain valid for use in a confirming response for no more
 
 **Note:** Once the FQDN has been validated using this method, the CA MAY also issue Certificates for other FQDNs that end with all the labels of the validated FQDN. This method is suitable for validating Wildcard Domain Names.
 
-#### 3.2.2.4.18 Agreed-Upon Change to Website v2
+##### 3.2.2.4.18 Agreed-Upon Change to Website v2
 
-Confirming the Applicant's control over the FQDN by verifying that the Request Token or Random Value is contained in the contents of a file. 
+Confirming the Applicant's control over the FQDN by verifying that the Request Token or Random Value is contained in the contents of a file.
 1.	The entire Request Token or Random Value MUST NOT appear in the request used to retrieve the file, and
 2.	the CA MUST receive a successful HTTP response from the request (meaning a 2xx HTTP status code must be received).
 
-The file containing the Request Token or Random Number: 
+The file containing the Request Token or Random Number:
 1.	MUST be located on the Authorization Domain Name, and
 2.	MUST be located under the "/.well-known/pki-validation" directory, and
 3.	MUST be retrieved via either the "http" or "https" scheme, and
@@ -771,7 +773,7 @@ If a Random Value is used, then:
 
 **Note:** Once the FQDN has been validated using this method, the CA MAY also issue Certificates for other FQDNs that end with all the labels of the validated FQDN. This method is suitable for validating Wildcard Domain Names.
 
-#### 3.2.2.4.19 Agreed-Upon Change to Website - ACME
+##### 3.2.2.4.19 Agreed-Upon Change to Website - ACME
 
 Confirming the Applicant's control over a FQDN by validating domain control of the FQDN using the ACME HTTP Challenge method defined in section 8.3 of RFC 8555. The following are additive requirements to RFC 8555.
 
@@ -797,14 +799,14 @@ Completed validations of Applicant authority may be valid for the issuance of mu
 
 After July 31, 2019, CAs SHALL maintain a record of which IP validation method, including the relevant BR version number, was used to validate every IP Address.
 
-**Note:** IP Addresses verified in accordance with this section 3.2.5 may be listed in Subscriber Certificates as defined in section 7.1.4.2 or in Subordinate CA Certificates via iPAddress in permittedSubtrees within the Name Constraints extension. CAs are not required to verify IP Addresses listed in Subordinate CA Certificates via iPAddress in excludedSubtrees in the Name Constraints extension prior to inclusion in the Subordinate CA Certificate.
+**Note:** IP Addresses verified in accordance with this section 3.2.2.5 may be listed in Subscriber Certificates as defined in section 7.1.4.2 or in Subordinate CA Certificates via iPAddress in permittedSubtrees within the Name Constraints extension. CAs are not required to verify IP Addresses listed in Subordinate CA Certificates via iPAddress in excludedSubtrees in the Name Constraints extension prior to inclusion in the Subordinate CA Certificate.
 
-##### 3.2.2.5.1. Agreed-Upon Change to Website
+##### 3.2.2.5.1 Agreed-Upon Change to Website
 Confirming the Applicant's control over the requested IP Address by confirming the presence of a Request Token or Random Value contained in the content of a file or webpage in the form of a meta tag under the "/.well-known/pki-validation" directory, or another path registered with IANA for the purpose of validating control of IP Addresses, on the IP Address that is accessible by the CA via HTTP/HTTPS over an Authorized Port. The Request Token or Random Value MUST NOT appear in the request.
 
 If a Random Value is used, the CA SHALL provide a Random Value unique to the certificate request and SHALL not use the Random Value after the longer of (i) 30 days or (ii) if the Applicant submitted the certificate request, the timeframe permitted for reuse of validated information relevant to the certificate (such as in Section 4.2.1 of this document).
 
-##### 3.2.2.5.2. Email, Fax, SMS, or Postal Mail to IP Address Contact
+##### 3.2.2.5.2 Email, Fax, SMS, or Postal Mail to IP Address Contact
 Confirming the Applicant's control over the IP Address  by sending a Random Value via email, fax, SMS, or postal mail and then receiving a confirming response utilizing the Random Value. The Random Value MUST be sent to an email address, fax/SMS number, or postal mail address identified as an IP Address Contact.
 
 Each email, fax, SMS, or postal mail MAY confirm control of multiple IP Addresses.
@@ -817,15 +819,15 @@ The CA MAY resend the email, fax, SMS, or postal mail in its entirety, including
 
 The Random Value SHALL remain valid for use in a confirming response for no more than 30 days from its creation. The CPS MAY specify a shorter validity period for Random Values, in which case the CA MUST follow its CPS.
 
-##### 3.2.2.5.3. Reverse Address Lookup
+##### 3.2.2.5.3 Reverse Address Lookup
  Confirming the Applicant’s control over the IP Address by obtaining a Domain Name associated with the IP Address through a reverse-IP lookup on the IP Address and then verifying control over the FQDN using a method permitted under BR Section 3.2.2.4.
 
-##### 3.2.2.5.4. Any Other Method
+##### 3.2.2.5.4 Any Other Method
 Using any other method of confirmation, including variations of the methods defined in BR Section 3.2.2.5, provided that the CA maintains documented evidence that the method of confirmation establishes that the Applicant has control over the IP Address to at least the same level of assurance as the methods previously described in version 1.6.2 of these Requirements.
 
 CAs SHALL NOT perform validations using this method after July 31, 2019.  Completed validations using this method SHALL NOT be re-used for certificate issuance after July 31, 2019. Any certificate issued prior to August 1, 2019 containing an IP Address that was validated using any method that was permitted under the prior version of this section 3.2.2.5 MAY continue to be used without revalidation until such certificate naturally expires.
 
-##### 3.2.2.5.5. Phone Contact with IP Address Contact
+##### 3.2.2.5.5 Phone Contact with IP Address Contact
 Confirming the Applicant's control over the IP Address by calling the IP Address Contact’s phone number and obtaining a response confirming the Applicant's request for validation of the IP Address. The CA MUST place the call to a phone number identified by the IP Address Registration Authority as the IP Address Contact. Each phone call SHALL be made to a single number.
 
 In the event that someone other than an IP Address Contact is reached, the CA MAY request to be transferred to the IP Address Contact.
@@ -862,15 +864,15 @@ Prior to using any data source as a Reliable Data Source, the CA SHALL evaluate 
 
 Databases maintained by the CA, its owner, or its affiliated companies do not qualify as a Reliable Data Source if the primary purpose of the database is to collect information for the purpose of fulfilling the validation requirements under this Section 3.2.
 
-#### 3.2.2.8. CAA Records
+#### 3.2.2.8 CAA Records
 
-As part of the issuance process, the CA MUST check for CAA records and follow the processing instructions found, for each dNSName in the subjectAltName extension of the certificate to be issued, as specififed in RFC 6844 as amended by Errata 5065 (Appendix A). If the CA issues, they MUST do so within the TTL of the CAA record, or 8 hours, whichever is greater.
+As part of the issuance process, the CA MUST check for CAA records and follow the processing instructions found, for each dNSName in the subjectAltName extension of the certificate to be issued, as specified in RFC 8659. If the CA issues, they MUST do so within the TTL of the CAA record, or 8 hours, whichever is greater.
 
 This stipulation does not prevent the CA from checking CAA records at any other time.
 
-When processing CAA records, CAs MUST process the issue, issuewild, and iodef property tags as specified in RFC 6844, although they are not required to act on the contents of the iodef property tag. Additional property tags MAY be supported, but MUST NOT conflict with or supersede the mandatory property tags set out in this document. CAs MUST respect the critical flag and not issue a certificate if they encounter an unrecognized property tag with this flag set. CAs MAY treat a non-empty CAA Resource Record Set that does not contain any issue property tags (and also does not contain any issuewild property tags when performing CAA processing for a Wildcard Domain Name) as permission to issue, provided that no records in the CAA Resource Record Set otherwise prohibit issuance.
+When processing CAA records, CAs MUST process the issue, issuewild, and iodef property tags as specified in RFC 8659, although they are not required to act on the contents of the iodef property tag. Additional property tags MAY be supported, but MUST NOT conflict with or supersede the mandatory property tags set out in this document. CAs MUST respect the critical flag and not issue a certificate if they encounter an unrecognized property tag with this flag set.
 
-RFC 6844 requires that CAs "MUST NOT issue a certificate unless either (1) the certificate request is consistent with the applicable CAA Resource Record set or (2) an exception specified in the relevant Certificate Policy or Certification Practices Statement applies." For issuances conforming to these Baseline Requirements, CAs MUST NOT rely on any exceptions specified in their CP or CPS unless they are one of the following:
+RFC 8659 requires that CAs "MUST NOT issue a certificate unless the CA determines that either (1) the certificate request is consistent with the applicable CAA RRset or (2) an exception specified in the relevant CP or CPS applies." For issuances conforming to these Baseline Requirements, CAs MUST NOT rely on any exceptions specified in their CP or CPS unless they are one of the following:
 
 *	CAA checking is optional for certificates for which a Certificate Transparency pre-certificate was created and logged in at least two public logs, and for which CAA was checked.
 *	CAA checking is optional for certificates issued by a Technically Constrained Subordinate CA Certificate as set out in Baseline Requirements section 7.1.5, where the lack of CAA checking is an explicit contractual provision in the contract with the Applicant.
@@ -879,7 +881,7 @@ RFC 6844 requires that CAs "MUST NOT issue a certificate unless either (1) the c
 CAs are permitted to treat a record lookup failure as permission to issue if:
 
 *	the failure is outside the CA's infrastructure; and
-*	the lookup has been retried at least once; and 
+*	the lookup has been retried at least once; and
 *	the domain's zone does not have a DNSSEC validation chain to the ICANN root.
 
 CAs MUST document potential issuances that were prevented by a CAA record in sufficient detail to provide feedback to the CAB Forum on the circumstances, and SHOULD dispatch reports of such issuance requests to the contact(s) stipulated in the CAA iodef record(s), if present. CAs are not expected to support URL schemes in the iodef record other than mailto: or https:.
@@ -937,7 +939,7 @@ The certificate request MUST contain a request from, or on behalf of, the Applic
 ### 4.2.1 Performing identification and authentication functions
 The certificate request MAY include all factual information about the Applicant to be included in the Certificate, and such additional information as is necessary for the CA to obtain from the Applicant in order to comply with these Requirements and the CA's Certificate Policy and/or Certification Practice Statement. In cases where the certificate request does not contain all the necessary information about the Applicant, the CA SHALL obtain the remaining information from the Applicant or, having obtained it from a reliable, independent, third-party data source, confirm it with the Applicant. The CA SHALL establish and follow a documented procedure for verifying all data requested for inclusion in the Certificate by the Applicant.
 
-Applicant information MUST include, but not be limited to, at least one Fully-Qualified Domain Name or IP address to be included in the Certificate's SubjectAltName extension.
+Applicant information MUST include, but not be limited to, at least one Fully-Qualified Domain Name or IP address to be included in the Certificate's subjectAltName extension.
 
 Section 6.3.2 limits the validity period of Subscriber Certificates. The CA MAY use the documents and data provided in Section 3.2 to verify certificate information, or may reuse previous validations themselves, provided that the CA obtained the data or document from a source specified under Section 3.2 or completed the validation itself no more than 825 days prior to issuing the Certificate.
 
@@ -1062,7 +1064,8 @@ The CA SHALL revoke a Certificate within 24 hours if one or more of the followin
 1. The Subscriber requests in writing that the CA revoke the Certificate;
 2. The Subscriber notifies the CA that the original certificate request was not authorized and does not retroactively grant authorization;
 3. The CA obtains evidence that the Subscriber's Private Key corresponding to the Public Key in the Certificate suffered a Key Compromise;
-4. The CA obtains evidence that the validation of domain authorization or control for any Fully-Qualified Domain Name or IP address in the Certificate should not be relied upon.
+4. The CA is made aware of a demonstrated or proven method that can easily compute the Subscriber's Private Key based on the Public Key in the Certificate (such as a Debian weak key, see https://wiki.debian.org/SSLkeys);
+5. The CA obtains evidence that the validation of domain authorization or control for any Fully-Qualified Domain Name or IP address in the Certificate should not be relied upon.
 
 The CA SHOULD revoke a certificate within 24 hours and MUST revoke a Certificate within 5 days if one or more of the following occurs:
 
@@ -1076,7 +1079,7 @@ The CA SHOULD revoke a certificate within 24 hours and MUST revoke a Certificate
 8. The CA determines or is made aware that any of the information appearing in the Certificate is inaccurate;
 9. The CA's right to issue Certificates under these Requirements expires or is revoked or terminated, unless the CA has made arrangements to continue maintaining the CRL/OCSP Repository;
 10. Revocation is required by the CA's Certificate Policy and/or Certification Practice Statement; or
-11. The CA is made aware of a demonstrated or proven method that exposes the Subscriber's Private Key to compromise, methods have been developed that can easily calculate it based on the Public Key (such as a Debian weak key, see http://wiki.debian.org/SSLkeys), or if there is clear evidence that the specific method used to generate the Private Key was flawed.
+11. The CA is made aware of a demonstrated or proven method that exposes the Subscriber's Private Key to compromise or if there is clear evidence that the specific method used to generate the Private Key was flawed.
 
 #### 4.9.1.2 Reasons for Revoking a Subordinate CA Certificate
 The Issuing CA SHALL revoke a Subordinate CA Certificate within seven (7) days if one or more of the following occurs:
@@ -1419,31 +1422,37 @@ The business continuity plan MUST include:
 ### 6.1.1 Key pair generation
 
 #### 6.1.1.1 CA Key Pair Generation
-For Root CA Key Pairs that are either (i) used as Root CA Key Pairs or (ii) Key Pairs generated for a subordinate CA that is not the operator of the Root CA or an Affiliate of the Root CA, the CA SHALL:
+For CA Key Pairs that are either (i) used as a CA Key Pair for a Root Certificate or (ii) used as a CA Key Pair for a Subordinate CA Certificate, where the Subordinate CA is not the operator of the Root CA or an Affiliate of the Root CA, the CA SHALL:
 
 1. prepare and follow a Key Generation Script,
-2. have a Qualified Auditor witness the Root CA Key Pair generation process or record a video of the entire Root CA Key Pair generation process, and
+2. have a Qualified Auditor witness the CA Key Pair generation process or record a video of the entire CA Key Pair generation process, and
 3. have a Qualified Auditor issue a report opining that the CA followed its key ceremony during its Key and Certificate generation process and the controls used to ensure the integrity and confidentiality of the Key Pair.
 
 For other CA Key Pairs that are for the operator of the Root CA or an Affiliate of the Root CA, the CA SHOULD:
 
 1. prepare and follow a Key Generation Script and
-2. have a Qualified Auditor witness the Root CA Key Pair generation process or record a video of the entire Root CA Key Pair generation process.
+2. have a Qualified Auditor witness the CA Key Pair generation process or record a video of the entire CA Key Pair generation process.
 
 In all cases, the CA SHALL:
 
-1. generate the keys in a physically secured environment as described in the CA's Certificate Policy and/or Certification Practice Statement;
-2. generate the CA keys using personnel in Trusted Roles under the principles of multiple person control and split knowledge;
-3. generate the CA keys within cryptographic modules meeting the applicable technical and business requirements as disclosed in the CA's Certificate Policy and/or Certification Practice Statement;
-4. log its CA key generation activities; and
+1. generate the CA Key Pair in a physically secured environment as described in the CA's Certificate Policy and/or Certification Practice Statement;
+2. generate the CA Key Pair using personnel in Trusted Roles under the principles of multiple person control and split knowledge;
+3. generate the CA Key Pair within cryptographic modules meeting the applicable technical and business requirements as disclosed in the CA's Certificate Policy and/or Certification Practice Statement;
+4. log its CA Key Pair generation activities; and
 5. maintain effective controls to provide reasonable assurance that the Private Key was generated and protected in conformance with the procedures described in its Certificate Policy and/or Certification Practice Statement and (if applicable) its Key Generation Script.
 
 #### 6.1.1.2 RA Key Pair Generation
 
 #### 6.1.1.3 Subscriber Key Pair Generation
-The CA SHALL reject a certificate request if the requested Public Key does not meet the requirements set forth in Sections 6.1.5 and 6.1.6 or if it has a known weak Private Key (such as a Debian weak key, see <http://wiki.debian.org/SSLkeys>).
+The CA SHALL reject a certificate request if one or more of the following conditions are met:
 
-If the Subscriber Certificate will contain an extendedKeyUsage extension containing either the values id-kp-serverAuth [RFC5280] or anyExtendedKeyUsage [RFC5280], the CA SHALL NOT generate a Key Pair on behalf of a Subscriber, and SHALL NOT accept a certificate request using a Key Pair previously generated by the CA. 
+1. The Key Pair does not meet the requirements set forth in Section 6.1.5 and/or Section 6.1.6;
+2. There is clear evidence that the specific method used to generate the Private Key was flawed;
+3. The CA is aware of a demonstrated or proven method that exposes the Applicant's Private Key to compromise;
+4. The CA has previously been made aware that the Applicant's Private Key has suffered a Key Compromise, such as through the provisions of Section 4.9.1.1;
+5. The CA is aware of a demonstrated or proven method to easily compute the Applicant's Private Key based on the Public Key (such as a Debian weak key, see https://wiki.debian.org/SSLkeys).
+
+If the Subscriber Certificate will contain an extKeyUsage extension containing either the values id-kp-serverAuth [RFC5280] or anyExtendedKeyUsage [RFC5280], the CA SHALL NOT generate a Key Pair on behalf of a Subscriber, and SHALL NOT accept a certificate request using a Key Pair previously generated by the CA.
 
 ### 6.1.2 Private key delivery to subscriber
 Parties other than the Subscriber SHALL NOT archive the Subscriber Private Key without authorization by the Subscriber.
@@ -1574,7 +1583,7 @@ c. `certificatePolicies`
 
    This extension SHOULD NOT be present.
 
-d. `extendedKeyUsage`
+d. `extKeyUsage`
 
    This extension MUST NOT be present.
 
@@ -1603,9 +1612,9 @@ b. `cRLDistributionPoints`
 c. `authorityInformationAccess`
 
    This extension SHOULD be present. It MUST NOT be marked critical.
-   
+
    It SHOULD contain the HTTP URL of the Issuing CA's certificate (`accessMethod` = 1.3.6.1.5.5.7.48.2).
-   It MAY contain the HTTP URL of the Issuing CA's OCSP responder (`accessMethod` = 1.3.6.1.5.5.7.48.1). 
+   It MAY contain the HTTP URL of the Issuing CA's OCSP responder (`accessMethod` = 1.3.6.1.5.5.7.48.1).
 
 d. `basicConstraints`
 
@@ -1621,7 +1630,7 @@ f. `nameConstraints` (optional)
 
 [^*]: Non-critical Name Constraints are an exception to RFC 5280 (4.2.1.10), however, they MAY be used until the Name Constraints extension is supported by Application Software Suppliers whose software is used by a substantial portion of Relying Parties worldwide.
 
-g. `extkeyUsage` (optional/required)
+g. `extKeyUsage` (optional/required)
 
    For Cross Certificates that share a Subject Distinguished Name and Subject Public Key with a Root Certificate operated in accordance with these Requirements, this extension MAY be present. If present, this extension SHOULD NOT be marked critical. This extension MUST only contain usages for which the issuing CA has verified the Cross Certificate is authorized to assert. This extension MAY contain the `anyExtendedKeyUsage` [RFC5280] usage, if the Root Certificate(s) associated with this Cross Certificate are operated by the same organization as the issuing Root Certificate.
 
@@ -1631,7 +1640,7 @@ g. `extkeyUsage` (optional/required)
 
    For Subordinate CA Certificates that will be used to issue TLS certificates, the value `id-kp-serverAuth` [RFC5280] MUST be present. The value `id-kp-clientAuth` [RFC5280] MAY be present. The values `id-kp-emailProtection` [RFC5280], `id-kp-codeSigning` [RFC5280], `id-kp-timeStamping` [RFC5280], and `anyExtendedKeyUsage` [RFC5280] MUST NOT be present. Other values SHOULD NOT be present.
 
-   For Subordinate CA Certificates that are not used to issue TLS certificates, then the value `id-kp-serverAuth` [RFC5280] MUST NOT be present. Other values MAY be present, but SHOULD NOT combine multiple independent usages (e.g. including `id-kp-timeStamping` [RFC5280] with `id-kp-codeSigning` [RFC5280]).
+   For Subordinate CA Certificates that are not used to issue TLS certificates, then the value `id-kp-serverAuth` [RFC5280] MUST NOT be present. Other values MAY be present, but SHOULD NOT combine multiple independent key purposes (e.g. including `id-kp-timeStamping` [RFC5280] with `id-kp-codeSigning` [RFC5280]).
 
 [^**]: While RFC 5280, Section 4.2.1.12, notes that this extension will generally only appear within end-entity certificates, these Requirements make use of this extension to further protect relying parties by limiting the scope of subordinate certificates, as implemented by a number of Application Software Suppliers.
 
@@ -1683,16 +1692,16 @@ g. `authorityKeyIdentifier` (required)
    This extension MUST be present and MUST NOT be marked critical. It MUST contain a `keyIdentifier` field and it MUST NOT contain a `authorityCertIssuer` or `authorityCertSerialNumber` field.
 
 #### 7.1.2.4 All Certificates
-All other fields and extensions MUST be set in accordance with RFC 5280. The CA SHALL NOT issue a Certificate that contains a `keyUsage` flag, `extendedKeyUsage` value, Certificate extension, or other data not specified in section 7.1.2.1, 7.1.2.2, or 7.1.2.3  unless the CA is aware of a reason for including the data in the Certificate.
+All other fields and extensions MUST be set in accordance with RFC 5280. The CA SHALL NOT issue a Certificate that contains a `keyUsage` flag, `extKeyUsage` value, Certificate extension, or other data not specified in section 7.1.2.1, 7.1.2.2, or 7.1.2.3  unless the CA is aware of a reason for including the data in the Certificate.
 
 CAs SHALL NOT issue a Certificate with:
 
-a. Extensions that do not apply in the context of the public Internet (such as an extendedKeyUsage value for a service that is only valid in the context of a privately managed network), unless:
+a. Extensions that do not apply in the context of the public Internet (such as an extKeyUsage value for a service that is only valid in the context of a privately managed network), unless:
 
    i. such value falls within an OID arc for which the Applicant demonstrates ownership, or
    ii. the Applicant can otherwise demonstrate the right to assert the data in a public context; or
 
-b. semantics that, if included, will mislead a Relying Party about the certificate information verified by the CA (such as including extendedKeyUsage value for a smart card, where the CA is not able to verify that the corresponding Private Key is confined to such hardware due to remote issuance).
+b. semantics that, if included, will mislead a Relying Party about the certificate information verified by the CA (such as including an extKeyUsage value for a smart card, where the CA is not able to verify that the corresponding Private Key is confined to such hardware due to remote issuance).
 
 #### 7.1.2.5 Application of RFC 5280
 For purposes of clarification, a Precertificate, as described in RFC 6962 - Certificate Transparency, shall not be considered to be a "certificate" subject to the requirements of RFC 5280 - Internet X.509 Public Key Infrastructure Certificate and Certificate Revocation List (CRL) Profile under these Baseline Requirements.
@@ -1788,10 +1797,10 @@ In addition, the CA MAY use the following signature algorithm and encoding if al
   * The only differences between the new Certificate and existing Certificate are one of the following:
     * A new `subjectPublicKey` within the `subjectPublicKeyInfo`, using the same algorithm and key size; and/or,
     * A new `serialNumber`, of the same encoded length as the existing Certificate; and/or
-    * The new Certificate's `extendedKeyUsage` extension is present, has at least one key usage specified, and none of the key usages specified are the id-kp-serverAuth (OID: 1.3.6.1.5.5.7.3.1) or the anyExtendedKeyUsage (OID: 2.5.2937.0) key usages; and/or
+    * The new Certificate's `extKeyUsage` extension is present, has at least one key purpose specified, and none of the key purposes specified are the id-kp-serverAuth (OID: 1.3.6.1.5.5.7.3.1) or the anyExtendedKeyUsage (OID: 2.5.2937.0) key purposes; and/or
     * The new Certificate's `basicConstraints` extension has a pathLenConstraint that is zero.
 * If used within an OCSP response, such as the `signatureAlgorithm` of a BasicOCSPResponse:
-  * All unexpired, un-revoked Certificates that contain the Public Key of the CA Key Pair and that have the same Subject Name MUST also contain an `extendedKeyUsage` extension with the only key usage present being the id-kp-ocspSigning (OID: 1.3.6.1.5.5.7.3.9) key usage.
+  * All unexpired, un-revoked Certificates that contain the Public Key of the CA Key Pair and that have the same Subject Name MUST also contain an `extKeyUsage` extension with the only key usage present being the id-kp-ocspSigning (OID: 1.3.6.1.5.5.7.3.9) key usage.
 * If used within a CRL, such as the `signatureAlgorithm` field of a CertificateList or the `signature` field of a TBSCertList:
   * The CRL is referenced by one or more Root CA or Subordinate CA Certificates; and,
   * The Root CA or Subordinate CA Certificate has issued one or more Certificates using the following encoding for the signature algorithm.
@@ -1829,7 +1838,7 @@ By issuing the Certificate, the CA represents that it followed the procedure set
 
 Subject attributes MUST NOT contain only metadata such as '.', '-', and ' ' (i.e. space) characters, and/or any other indication that the value is absent, incomplete, or not applicable.
 
-#### 7.1.4.2.1 Subject Alternative Name Extension
+##### 7.1.4.2.1 Subject Alternative Name Extension
 
 __Certificate Field:__ `extensions:subjectAltName`  
 __Required/Optional:__ Required  
@@ -1837,11 +1846,11 @@ __Contents:__ This extension MUST contain at least one entry. Each entry MUST be
 
 Wildcard FQDNs are permitted.
 
-CAs SHALL NOT issue certificates with a subjectAlternativeName extension or Subject commonName field containing a Reserved IP Address or Internal Name.
+CAs SHALL NOT issue certificates with a subjectAltName extension or subject:commonName field containing a Reserved IP Address or Internal Name.
 
 Entries in the dNSName MUST be in the "preferred name syntax", as specified in RFC 5280, and thus MUST NOT contain underscore characters ("_").
 
-#### 7.1.4.2.2. Subject Distinguished Name Fields
+##### 7.1.4.2.2 Subject Distinguished Name Fields
 a. __Certificate Field:__ `subject:commonName` (OID 2.5.4.3)  
    __Required/Optional:__ __Deprecated__ (Discouraged, but not prohibited)  
    __Contents:__ If present, this field MUST contain a single IP address or Fully-Qualified Domain Name that is one of the values contained in the Certificate's subjectAltName extension (see Section 7.1.4.2.1).
@@ -1852,7 +1861,7 @@ b. __Certificate Field:__ `subject:organizationName` (OID 2.5.4.10)
 
 c. __Certificate Field:__ `subject:givenName` (2.5.4.42) and `subject:surname` (2.5.4.4)  
    __Required/Optional:__ __Optional__.  
-   __Contents:__ If present, the `subject:givenName` field and `subject:surname` field MUST contain an natural person Subject’s name as verified under Section 3.2.3. A Certificate containing a `subject:givenName` field or `subject:surname` field MUST contain the (2.23.140.1.2.3) Certificate Policy OID.
+   __Contents:__ If present, the `subject:givenName` field and `subject:surname` field MUST contain a natural person Subject’s name as verified under Section 3.2.3. A Certificate containing a `subject:givenName` field or `subject:surname` field MUST contain the (2.23.140.1.2.3) Certificate Policy OID.
 
 d. __Certificate Field:__ Number and street: `subject:streetAddress` (OID: 2.5.4.9)  
    __Required/Optional:__  
@@ -1886,17 +1895,17 @@ h. __Certificate Field:__ `subject:countryName` (OID: 2.5.4.6)
    __Optional__ if the `subject:organizationName` field, `subject:givenName` field, and `subject:surname` field are absent.  
    __Contents:__ If the `subject:organizationName` field is present, the `subject:countryName` MUST contain the two-letter ISO 3166-1 country code associated with the location of the Subject verified under Section 3.2.2.1. If the `subject:organizationName` field is absent, the `subject:countryName` field MAY contain the two-letter ISO 3166-1 country code associated with the Subject as verified in accordance with Section 3.2.2.3. If a Country is not represented by an official ISO 3166-1 country code, the CA MAY specify the ISO 3166-1 user-assigned code of XX indicating that an official ISO 3166-1 alpha-2 code has not been assigned.
 
-i. __Certificate Field:__ `subject:organizationalUnitName` (OID: 2.5.4.11)
+i. __Certificate Field:__ `subject:organizationalUnitName` (OID: 2.5.4.11)  
    __Required/Optional:__ __Optional__.  
    __Contents__: The CA SHALL implement a process that prevents an OU attribute from including a name, DBA, tradename, trademark, address, location, or other text that refers to a specific natural person or Legal Entity unless the CA has verified this information in accordance with Section 3.2 and the Certificate also contains `subject:organizationName`, `subject:givenName`, `subject:surname`, `subject:localityName`, and `subject:countryName` attributes, also verified in accordance with Section 3.2.2.1.
 
-j. Other Subject Attributes
-Other attributes MAY be present within the subject field. If present, other attributes MUST contain information that has been verified by the CA.
+j. Other Subject Attributes  
+   Other attributes MAY be present within the subject field. If present, other attributes MUST contain information that has been verified by the CA.
 
-#### 7.1.4.3. Subject Information - Root Certificates and Subordinate CA Certificates
+#### 7.1.4.3 Subject Information - Root Certificates and Subordinate CA Certificates
 By issuing a Subordinate CA Certificate, the CA represents that it followed the procedure set forth in its Certificate Policy and/or Certification Practice Statement to verify that, as of the Certificate's issuance date, all of the Subject Information was accurate.
 
-##### 7.1.4.3.1. Subject Distinguished Name Fields
+##### 7.1.4.3.1 Subject Distinguished Name Fields
 
 a.  __Certificate Field:__ `subject:commonName` (OID 2.5.4.3)  
     __Required/Optional:__ Required  
@@ -1917,7 +1926,7 @@ If the Subordinate CA Certificate includes the id-kp-serverAuth extended key usa
 
 a. For each dNSName in permittedSubtrees, the CA MUST confirm that the Applicant has registered the dNSName or has been authorized by the domain registrant to act on the registrant's behalf in line with the verification practices of section 3.2.2.4.
 b. For each iPAddress range in permittedSubtrees, the CA MUST confirm that the Applicant has been assigned the iPAddress range or has been authorized by the assigner to act on the assignee's behalf.
-c. For each DirectoryName in permittedSubtrees the CA MUST confirm the Applicants and/or Subsidiary's Organizational name and location such that end entity certificates issued from the subordinate CA Certificate will be in compliancy with section 7.1.2.4 and 7.1.2.5.
+c. For each DirectoryName in permittedSubtrees, the CA MUST confirm the Applicant's and/or Subsidiary's Organizational name and location such that end entity certificates issued from the subordinate CA Certificate will be in compliance with section 7.1.2.4 and 7.1.2.5.
 
 If the Subordinate CA Certificate is not allowed to issue certificates with an iPAddress, then the Subordinate CA Certificate MUST specify the entire IPv4 and IPv6 address ranges in excludedSubtrees. The Subordinate CA Certificate MUST include within excludedSubtrees an iPAddress GeneralName of 8 zero octets (covering the IPv4 address range of 0.0.0.0/0). The Subordinate CA Certificate MUST also include within excludedSubtrees an iPAddress GeneralName of 32 zero octets (covering the IPv6 address range of ::0/0). Otherwise, the Subordinate CA Certificate MUST include at least one iPAddress in permittedSubtrees.
 
@@ -1937,43 +1946,59 @@ If the Subordinate CA is not allowed to issue certificates with dNSNames, then t
 
 ### 7.1.6 Certificate policy object identifier
 
-#### 7.1.6.1. Reserved Certificate Policy Identifiers
 This section describes the content requirements for the Root CA, Subordinate CA, and Subscriber Certificates, as they relate to the identification of Certificate Policy.
 
-The following Certificate Policy identifiers are reserved for use by CAs as a means of asserting compliance with these Requirements as follows:
+#### 7.1.6.1 Reserved Certificate Policy Identifiers
 
-`{joint-iso-itu-t(2) international-organizations(23) ca-browser-forum(140) certificate-policies(1) baseline-requirements(2) domain-validated(1)} (2.23.140.1.2.1)`, if the Certificate complies with these Requirements but lacks Subject Identity Information that is verified in accordance with Section 3.2.2.1 or Section 3.2.3.
+The following Certificate Policy identifiers are reserved for use by CAs as an optional means of asserting that a Certificate complies with these Requirements.
 
-If the Certificate asserts the policy identifier of 2.23.140.1.2.1, then it MUST NOT include organizationName, givenName, surname, streetAddress, localityName, stateOrProvinceName, or postalCode in the Subject field.
+`{joint-iso-itu-t(2) international-organizations(23) ca-browser-forum(140) certificate-policies(1) baseline-requirements(2) domain-validated(1)} (2.23.140.1.2.1)`
 
-`{joint-iso-itu-t(2) international-organizations(23) ca-browser-forum(140) certificate-policies(1) baseline-requirements(2) organization-validated(2)} (2.23.140.1.2.2)`, if the Certificate complies with these Requirements and includes Subject Identity Information that is verified in accordance with Section 3.2.2.1.
+`{joint-iso-itu-t(2) international-organizations(23) ca-browser-forum(140) certificate-policies(1) baseline-requirements(2) organization-validated(2)} (2.23.140.1.2.2)`
 
-`{joint-iso-itu-t(2) international-organizations(23) ca-browser-forum(140) certificate-policies(1) baseline-requirements(2) individual-validated(3)} (2.23.140.1.2.3)`, if the Certificate complies with these Requirements and includes Subject Identity Information that is verified in accordance with Section 3.2.3.
+`{joint-iso-itu-t(2) international-organizations(23) ca-browser-forum(140) certificate-policies(1) baseline-requirements(2) individual-validated(3)} (2.23.140.1.2.3)`
 
-If the Certificate asserts the policy identifier of 2.23.140.1.2.2, then it MUST also include `organizationName`, `localityName` (to the extent such field is required under Section 7.1.4.2.2), `stateOrProvinceName` (to the extent such field is required under Section 7.1.4.2.2), and `countryName` in the Subject field.  If the Certificate asserts the policy identifier of 2.23.140.1.2.3, then it MUST also include (i) either `organizationName` or `givenName` and `surname`, (ii) `localityName` (to the extent such field is required under Section 7.1.4.2.2), (iii) `stateOrProvinceName` (to the extent required under Section 7.1.4.2.2), and (iv) `countryName` in the Subject field.
+`{joint‐iso‐itu‐t(2) international‐organizations(23) ca‐browser‐forum(140) certificate‐policies(1) ev-guidelines(1)} (2.23.140.1.1)`
 
-#### 7.1.6.2. Root CA Certificates
-A Root CA Certificate SHOULD NOT contain the `certificatePolicies` extension.
+#### 7.1.6.2 Root CA Certificates
+A Root CA Certificate SHOULD NOT contain the certificatePolicies extension. If present, the extension MUST conform to the requirements set forth for Certificates issued to Subordinate CAs in Section 7.1.6.3.
 
 #### 7.1.6.3 Subordinate CA Certificates
 A Certificate issued to a Subordinate CA that is not an Affiliate of the Issuing CA:
 
-1. MUST include one or more explicit policy identifiers that indicates the Subordinate CA's adherence to and compliance with these Requirements (i.e. either the CA/Browser Forum reserved identifiers or identifiers documented by the CA in its Certificate Policy and/or Certification Practice Statement) and
-2. MUST NOT contain the `anyPolicy` identifier (2.5.29.32.0).
+1. MUST include one or more explicit policy identifiers that indicate the Subordinate CA's adherence to and compliance with these Requirements (i.e. either the CA/Browser Forum Reserved Certificate Policy Identifiers or identifiers documented by the Subordinate CA in its Certificate Policy and/or Certification Practice Statement) and
+2. MAY contain one or more identifiers documented by the Subordinate CA in its Certificate Policy and/or Certification Practice Statement and
+3. MUST NOT contain the `anyPolicy` identifier (2.5.29.32.0).
 
 A Certificate issued to a Subordinate CA that is an affiliate of the Issuing CA:
 
-1. MAY include the CA/Browser Forum reserved identifiers or an identifier documented by the CA in its Certificate Policy and/or Certification Practice Statement to indicate the Subordinate CA's compliance with these Requirements and
-2. MAY contain the `anyPolicy` identifier (2.5.29.32.0) in place of an explicit policy identifier.
+1. MAY include one or more explicit policy identifiers that indicate the Subordinate CA's adherence to and compliance with these Requirements (i.e. either the CA/Browser Forum Reserved Certificate Policy Identifiers or identifiers documented by the  Subordinate CA in its Certificate Policy and/or Certification Practice Statement) and
+2. MAY contain one or more identifiers documented by the Subordinate CA in its Certificate Policy and/or Certification Practice Statement and
+3. MAY contain the `anyPolicy` identifier (2.5.29.32.0) in place of an explicit policy identifier.
 
-A Subordinate CA SHALL represent, in its Certificate Policy and/or Certification Practice Statement, that all Certificates containing a policy identifier indicating compliance with these Requirements are issued and managed in accordance with these Requirements.
+The Subordinate CA and the Issuing CA SHALL represent, in their Certificate Policy and/or Certification Practice Statement, that all Certificates containing a policy identifier indicating compliance with these Requirements are issued and managed in accordance with these Requirements.
 
 #### 7.1.6.4 Subscriber Certificates
-Effective 2020-09-30, a Certificate issued to a Subscriber MUST contain, within the Certificate's certificatePolicies extension, one or more policy identifier(s) that are specified beneath the CA/Browser Forum's reserved policy OID arc of {joint-iso-itu-t(2) international-organizations(23) ca-browser-forum(140) certificate-policies(1)} (2.23.140.1).
+Effective 2020-09-30, a Certificate issued to a Subscriber MUST contain, within the Certificate's certificatePolicies extension, one or more policy identifier(s) that are specified beneath the CA/Browser Forum's reserved policy OID arc of `{joint-iso-itu-t(2) international-organizations(23) ca-browser-forum(140) certificate-policies(1)} (2.23.140.1)`.
 
 The certificate MAY also contain additional policy identifier(s) defined by the Issuing CA. The issuing CA SHALL document in its Certificate Policy or Certification Practice Statement that the Certificates it issues containing the specified policy identifier(s) are managed in accordance with these requirements.
 
 For certificates issued prior to 2020-09-30, a Certificate issued to a Subscriber MUST contain a certificatePolicies extension. The extension MUST contain one or more policy identifiers that indicate adherence to and compliance with these Requirements. CAs MUST either use a CA/Browser Forum identifier reserved for this purpose or MUST use a policy identifier documented by the CA in its Certificate Policy and/or Certification Practice Statement to indicate the Certificate's compliance with these Requirements.
+
+Prior to including a Reserved Certificate Policy Identifier, the CA MUST ensure the following requirements are met:
+
+* __Certificate Policy Identifier:__ `2.23.140.1.2.1`  
+  If the Certificate complies with these requirements and lacks Subject identity information that has been verified in accordance with Section 3.2.2.1 or Section 3.2.3.  
+  Such Certificates MUST NOT include `organizationName`, `givenName`, `surname`, `streetAddress`, `localityName`, `stateOrProvinceName`, or `postalCode` in the Subject field.  
+* __Certificate Policy Identifier:__ `2.23.140.1.2.2`  
+  If the Certificate complies with these Requirements and includes Subject Identity Information that is verified in accordance with Section 3.2.2.1.  
+  Such Certificates MUST also include `organizationName`, `localityName` (to the extent such field is required under Section 7.1.4.2.2), `stateOrProvinceName` (to the extent such field is required under Section 7.1.4.2.2), and `countryName` in the Subject field.  
+* __Certificate Policy Identifier:__ `2.23.140.1.2.3`  
+  If the Certificate complies with these Requirements and includes Subject Identity Information that is verified in accordance with Section 3.2.3.  
+  Such Certificates MUST also include either `organizationName` or both `givenName` and `surname`, `localityName` (to the extent such field is required under Section 7.1.4.2.2), `stateOrProvinceName` (to the extent required under Section 7.1.4.2.2), and `countryName` in the Subject field.  
+* __Certificate Policy Identifier:__ `2.23.140.1.1`  
+  If the Certificate complies with these Requirements and has been issued and operated in accordance with the CA/Browser Forum Guidelines for the Issuance and Management of Extended Validation Certificates ("EV Guidelines").  
+  Such Certificates MUST also include Subject Identity Information as required and verified according to the EV Guidelines.  
 
 ### 7.1.7 Usage of Policy Constraints extension
 
@@ -1999,7 +2024,7 @@ For certificates issued prior to 2020-09-30, a Certificate issued to a Subscribe
   The `CRLReason` indicated MUST NOT be unspecified (0). If the reason for revocation is unspecified, CAs MUST omit `reasonCode` entry extension, if allowed by the previous requirements.
   If a CRL entry is for a Certificate not subject to these Requirements and was either issued on-or-after 2020-09-30 or has a `notBefore` on-or-after 2020-09-30, the `CRLReason` MUST NOT be certificateHold (6).
   If a CRL entry is for a Certificate subject to these Requirements, the `CRLReason` MUST NOT be certificateHold (6).
-  
+
   If a `reasonCode` CRL entry extension is present, the `CRLReason` MUST indicate the most appropriate reason for revocation of the certificate, as defined by the CA within its CP/CPS.
 
 ## 7.3 OCSP profile
@@ -2022,7 +2047,7 @@ The CA SHALL at all times:
 3. Comply with the audit requirements set forth in this section; and
 4. Be licensed as a CA in each jurisdiction where it operates, if licensing is required by the law of such jurisdiction for the issuance of Certificates.
 
-**Implementers' Note**: Version 1.1.6 of the SSL Baseline Requirements was published on July 29, 2013. Version 2.0 of WebTrust's Principles and Criteria for Certifiation Authorities - SSL Baseline with Network Security and ETSI's Electronic Signatures and Infrastructures (ESI) 102 042 incorporate version 1.1.6 of these Baseline Requirements and version 1.0 of the Network and Certificate System Security Requirements. The CA/Browser Forum continues to improve the Baseline Requirements while WebTrust and ETSI also continue to update their audit criteria. We encourage all CAs to conform to each revision herein on the date specified without awaiting a corresponding update to an applicable audit criterion. In the event of a conflict between an existing audit criterion and a guideline revision, we will communicate with the audit community and attempt to resolve any uncertainty, and we will respond to implementation questions directed to questions@cabforum.org. Our coordination with compliance auditors will continue as we develop guideline revision cycles that harmonize with the revision cycles for audit criteria, the compliance auditing periods and cycles of CAs, and the CA/Browser Forum's guideline implementation dates.
+**Implementers' Note**: Version 1.1.6 of the SSL Baseline Requirements was published on July 29, 2013. Version 2.0 of WebTrust's Principles and Criteria for Certification Authorities - SSL Baseline with Network Security and ETSI's Electronic Signatures and Infrastructures (ESI) 102 042 incorporate version 1.1.6 of these Baseline Requirements and version 1.0 of the Network and Certificate System Security Requirements. The CA/Browser Forum continues to improve the Baseline Requirements while WebTrust and ETSI also continue to update their audit criteria. We encourage all CAs to conform to each revision herein on the date specified without awaiting a corresponding update to an applicable audit criterion. In the event of a conflict between an existing audit criterion and a guideline revision, we will communicate with the audit community and attempt to resolve any uncertainty, and we will respond to implementation questions directed to questions@cabforum.org. Our coordination with compliance auditors will continue as we develop guideline revision cycles that harmonize with the revision cycles for audit criteria, the compliance auditing periods and cycles of CAs, and the CA/Browser Forum's guideline implementation dates.
 
 ## 8.1 Frequency or circumstances of assessment
 Certificates that are capable of being used to issue new certificates MUST either be Technically Constrained in line with section 7.1.5 and audited in line with section 8.7 only, or Unconstrained and fully audited in line with all remaining requirements from this section. A Certificate is deemed as capable of being used to issue new certificates if it contains an X.509v3 basicConstraints extension, with the `cA` boolean set to true and is therefore by definition a Root CA Certificate or a Subordinate CA Certificate.
@@ -2081,7 +2106,7 @@ The Audit Report MUST contain at least the following clearly-labelled informatio
 7. the start date and end date of the Audit Period, for those that cover a period of time;
 8. the point in time date, for those that are for a point in time;
 9. the date the report was issued, which will necessarily be after the end date or point in time date; and
-10. (for audits conducted in accordance with any of the ETSI standards) a statement to indicate if the audit was a full audit or a surveillance audit, and which portions of the criteria were applied and evaluated, e.g. DVCP, OVCP, NCP, NCP+, LCP, EVCP, EVCP+, QCP-w, Part 1 (General Requirements), and/or Part 2 (Requirements for Trust Service Providers). 
+10. (for audits conducted in accordance with any of the ETSI standards) a statement to indicate if the audit was a full audit or a surveillance audit, and which portions of the criteria were applied and evaluated, e.g. DVCP, OVCP, NCP, NCP+, LCP, EVCP, EVCP+, QCP-w, Part 1 (General Requirements), and/or Part 2 (Requirements for Trust Service Providers).
 11. (for audits conducted in accordance with any of the ETSI standards) a statement to indicate that the auditor referenced the applicable CA/Browser Forum criteria, such as this document, and the version used.
 
 An authoritative English language version of the publicly available audit information MUST be provided by the Qualified Auditor and the CA SHALL ensure it is publicly available.
@@ -2189,7 +2214,7 @@ The Subscriber Agreement or Terms of Use MUST contain provisions imposing on the
 5. **Reporting and Revocation**: An obligation and warranty to: (a) promptly request revocation of the Certificate, and cease using it and its associated Private Key, if there is any actual or suspected misuse or compromise of the Subscriber’s Private Key associated with the Public Key included in the Certificate, and (b) promptly request revocation of the Certificate, and cease using it, if any information in the Certificate is or becomes incorrect or inaccurate;
 6. **Termination of Use of Certificate**: An obligation and warranty to promptly cease all use of the Private Key corresponding to the Public Key included in the Certificate upon revocation of that Certificate for reasons of Key Compromise.
 7. **Responsiveness**: An obligation to respond to the CA's instructions concerning Key Compromise or Certificate misuse within a specified time period.
-8. **Acknowledgment and Acceptance**: An acknowledgment and acceptance that the CA is entitled to revoke the certificate immediately if the Applicant were to violate the terms of the Subscriber Agreement or Terms of Use or if the CA discovers that the Certificate is being used to enable criminal activities such as phishing attacks, fraud, or the distribution of malware.
+8. **Acknowledgment and Acceptance**: An acknowledgment and acceptance that the CA is entitled to revoke the certificate immediately if the Applicant were to violate the terms of the Subscriber Agreement or Terms of Use or if revocation is required by the CA's CP, CPS, or these Baseline Requirements.
 
 ### 9.6.4 Relying party representations and warranties
 
@@ -2250,75 +2275,13 @@ Any modification to CA practice enabled under this section MUST be discontinued 
 
 ## 9.17 Other provisions
 
-# APPENDIX A – RFC 6844 Errata 5065
-
-The following errata report has been held for document update for RFC6844, "DNS Certification Authority Authorization (CAA) Resource Record".
-
------
-
-You may review the report below and at:   http://www.rfc-editor.org/errata/eid5065
-
------
-
-Status: Held for Document Update
-Type: Technical
-
-Reported by: Phillip Hallam-Baker <philliph@comodo.com>
-Date Reported: 2017-07-10
-Held by: EKR (IESG)
-
-Section: 4
-
-Original Text
--------------
-```
-   Let CAA(X) be the record set returned in response to performing a CAA
-   record query on the label X, P(X) be the DNS label immediately above X in
-   the DNS hierarchy, and A(X) be the target of a CNAME or DNAME alias record
-   specified at the label X.
-
-   o  If CAA(X) is not empty, R(X) = CAA (X), otherwise
-   o  If A(X) is not null, and R(A(X)) is not empty, then R(X) =  R(A(X)),
-   otherwise
-   o  If X is not a top-level domain, then R(X) = R(P(X)), otherwise
-   o  R(X) is empty.
-```
-
-Corrected Text
---------------
-```
-   Let CAA(X) be the record set returned in response to performing a CAA
-   record query on the label X, P(X) be the DNS label immediately above X in
-   the DNS hierarchy, and A(X) be the target of a CNAME or DNAME alias record
-   chain specified at the label X.
-
-   o  If CAA(X) is not empty, R(X) = CAA (X), otherwise
-   o  If A(X) is not null, and CAA(A(X)) is not empty, then R(X) =  CAA(A(X)),
-   otherwise
-   o  If X is not a top-level domain, then R(X) = R(P(X)), otherwise
-   o  R(X) is empty.
-
-  Thus, when a search at node X returns a CNAME record, the CA will follow the
-  CNAME record chain to its target. If the target label contains a CAA record,
-  it is returned.
-
-  Otherwise, the CA continues the search at the parent of node X.
-
-  Note that the search does not include the parent of a target of a CNAME
-  record (except when the CNAME points back to its own path).
-
-  To prevent resource exhaustion attacks, CAs SHOULD limit the length of CNAME
-  chains that are accepted. However CAs MUST process CNAME chains that contain
-  8 or fewer CNAME records.
-```
-
-# APPENDIX B – CAA Contact Tag
+# APPENDIX A – CAA Contact Tag
 
 These methods allow domain owners to publish contact information in DNS for the purpose of validating domain control.
 
-## B.1. CAA Methods
+## A.1. CAA Methods
 
-### B.1.1. CAA contactemail Property
+### A.1.1. CAA contactemail Property
 
 SYNTAX: `contactemail <rfc6532emailaddress>`
 
@@ -2333,7 +2296,7 @@ $ORIGIN example.com.
 
 The contactemail property MAY be critical, if the domain owner does not want CAs who do not understand it to issue certificates for the domain.
 
-### B.1.2. CAA contactphone Property
+### A.1.2. CAA contactphone Property
 
 SYNTAX: `contactphone <rfc3966 Global Number>`
 
@@ -2346,21 +2309,22 @@ $ORIGIN example.com.
 
 The contactphone property MAY be critical if the domain owner does not want CAs who do not understand it to issue certificates for the domain.
 
-## B.2. DNS TXT Methods
+## A.2. DNS TXT Methods
 
-### B.2.1. DNS TXT Record Email Contact
+### A.2.1. DNS TXT Record Email Contact
 
 The DNS TXT record MUST be placed on the "`_validation-contactemail`" subdomain of the domain being validated.  The entire RDATA value of this TXT record MUST be a valid email address as defined in RFC 6532 section 3.2, with no additional padding or structure, or it cannot be used.
 
-### B.2.2. DNS TXT Record Phone Contact
+### A.2.2. DNS TXT Record Phone Contact
 The DNS TXT record MUST be placed on the "`_validation-contactphone`" subdomain of the domain being validated.  The entire RDATA value of this TXT record MUST be a valid Global Number as defined in RFC 3966 section 5.1.4, or it cannot be used.
 
-# APPENDIX C – Issuance of Certificates for .onion Domain Names
+# APPENDIX B – Issuance of Certificates for .onion Domain Names
+
 This appendix defines permissible verification procedures for including one or more RFC 7686 ".onion" special-use Domain Names in a Certificate.
 
 1. The Domain Name MUST contain at least two labels, where the right-most label is "onion", and the label immediately preceding the right-most "onion" label is a valid Version 3 Onion Address, as defined in section 6 of the Tor Rendezvous Specification - Version 3 located at <https://spec.torproject.org/rend-spec-v3>.
 2. The CA MUST verify the Applicant’s control over the .onion Domain Name using at least one of the methods listed below:
-    a. The CA MAY verify the Applicant’s control over the .onion service by using method 3.2.2.4.6, Agreed‐Upon Change to Website. If this method is replaced by a newer version(s) of Agreed-Upon Change to Website, the timelines for use of new and existing version of this method that are defined in section 3.2.2.4 SHALL apply.	
+    a. The CA MAY verify the Applicant’s control over the .onion service by using method 3.2.2.4.6, Agreed‐Upon Change to Website. If this method is replaced by a newer version(s) of Agreed-Upon Change to Website, the timelines for use of new and existing version of this method that are defined in section 3.2.2.4 SHALL apply.
     b. The CA MAY verify the Applicant's control over the .onion service by having the Applicant provide a Certificate Request signed using the .onion public key if the Attributes section of the certificationRequestInfo contains:
         (i) A caSigningNonce attribute that contains a Random Value that is generated by the CA; and
         (ii) An applicantSigningNonce attribute that contains a single value with at least 64-bits of entropy that is generated by the Applicant.
@@ -2388,4 +2352,4 @@ cabf-applicantSigningNonce OBJECT IDENTIFIER ::= { cabf 42 }
 The Random Value SHALL remain valid for use in a confirming response for no more than 30 days from its creation. The CPS MAY specify a shorter validity period for Random Values.
 The CA MAY include a wildcard character in the Subject Alternative Name Extension and Subject Common Name Field as the left-most character in the .onion Domain Name provided inclusion of the wildcard character complies with Section 3.2.2.6 of these Requirements.
 
-3. When a Certificate includes an FQDN where "onion" is in the right-most label of the Domain Name, the Domain Name shall not be considered an Internal Name provided that the Certificate was issued in compliance with this Appendix C.
+3. When a Certificate includes an FQDN where "onion" is in the right-most label of the Domain Name, the Domain Name shall not be considered an Internal Name provided that the Certificate was issued in compliance with this Appendix B.

--- a/docs/EVG.md
+++ b/docs/EVG.md
@@ -20,7 +20,7 @@ Copyright © 2007-2020, members of the CA/Browser Forum. This work is licensed u
 
 The CA/Browser Forum requests that translated versions of these guidelines prominently display the following statement in the language of the translation :-
 
-'Copyright © 2007-2020, members of the CA/Browser Forum. This work is licensed under a Creative Commons Attribution 4.0 International license. 
+'Copyright © 2007-2020, members of the CA/Browser Forum. This work is licensed under a Creative Commons Attribution 4.0 International license.
 
 This document is a translation of the original English version. In the event that there is a discrepancy between this version and the original English version, the original English version shall govern.'
 
@@ -84,7 +84,7 @@ The CA/Browser Forum is a voluntary open organization of certification authoriti
 
 | **Compliance** | **Section(s)** | **Summary Description (See Full Text for Details)** |
 | --- | --- | --- |
-| 2020-01-31 | 9.2.8 | If subject:organizationIdentifier is present, the Subject Organization Identifier Extension MUST be present |
+| 2020-01-31 | 9.2.8 | If subject:organizationIdentifier is present, the CA/Browser Forum Organization Identifier Extension MUST be present |
 | 2020-09-01 | 9.4 & Appendix F | Certificates issued MUST NOT have a Validity Period greater than 398 days. |
 | 2020-10-01 | 11.1.3 | Prior to using an Incorporating Agency or Registration Agency, the CA MUST ensure the agency has been publicly disclosed |
 
@@ -112,7 +112,7 @@ The primary purposes of an EV Certificate are to:
 
  (2) **Enable encrypted communications with a Web site:**  Facilitate the exchange of encryption keys in order to enable the encrypted communication of information over the Internet between the user of an Internet browser and a Web site.
 
-### 2.1.2  Secondary Purposes
+### 2.1.2.  Secondary Purposes
 
 The secondary purposes of an EV Certificate are to help establish the legitimacy of a business claiming to operate a Web site or distribute executable code, and to provide a vehicle that can be used to assist in addressing problems related to phishing, malware, and other forms of online identity fraud.  By providing more reliable third-party verified identity and address information regarding the business, EV Certificates may help to:
 
@@ -350,7 +350,7 @@ Each CA must develop, implement, enforce, display prominently on its Web site, a
 
 Each CA MUST publicly disclose its Certificate Policy and/or Certification Practice Statement through an appropriate and readily accessible online means that is available on a 24x7 basis. The CA SHALL publicly disclose its CA business practices to the extent required by the CA's selected audit scheme (see Section 17.1).
 
-Effective as of 31 May 2018, the CA's Certificate Policy and/or Certification Practice Statement MUST be structured in accordance with RFC 3647. Prior to 31 May 2018, the CA's Certificate Policy and/or Certification Practice Statement MUST be structured in accordance with either RFC 2527 or RFC 3647. The Certificate Policy and/or Certification Practice Statement MUST include all material required by RFC 3647 or, if structured as such, RFC 2527.
+The CA's Certificate Policy and/or Certification Practice Statement MUST be structured in accordance with RFC 3647. The Certificate Policy and/or Certification Practice Statement MUST include all material required by RFC 3647.
 
 ## 8.3.  Commitment to Comply with Recommendations
 
@@ -510,7 +510,7 @@ For Government Entities that do not have a Registration Number or readily verifi
 
 For Business Entities, the Registration Number that was received by the Business Entity upon government registration SHALL be entered in this field.  For those Business Entities that register with an Incorporating Agency or Registration Agency in a jurisdiction that does not issue numbers pursuant to government registration, the date of the registration SHALL be entered into this field in any one of the common date formats.
 
-Effective as of 1 October 2020, if the CA has disclosed a set of acceptable format or formats for Registration Numbers for the applicable Registration Agency or Incorporating Agency, as described in Section 11.1.3, the CA MUST ensure, prior to issuance, that the Registration Number is valid according to at least one currently disclosed format for that applicable Registration Agency or Incorporating agency. 
+Effective as of 1 October 2020, if the CA has disclosed a set of acceptable format or formats for Registration Numbers for the applicable Registration Agency or Incorporating Agency, as described in Section 11.1.3, the CA MUST ensure, prior to issuance, that the Registration Number is valid according to at least one currently disclosed format for that applicable Registration Agency or Incorporating agency.
 
 ### 9.2.6.  Subject Physical Address of Place of Business Field
 
@@ -571,9 +571,8 @@ Registration Schemes listed in Appendix H are currently recognized as valid unde
 
 The CA SHALL:
 
-1. confirm that the organization represented by the Registration Reference is the same as the organization named in the organizationName field as specified in Section 9.2.1 within the context of the subject’s jurisdiction as specified in 
-   Section 9.2.4;
-2. further verify the Registration Reference matches other information verified in accordance with section 11; 
+1. confirm that the organization represented by the Registration Reference is the same as the organization named in the organizationName field as specified in Section 9.2.1 within the context of the subject’s jurisdiction as specified in Section 9.2.4;
+2. further verify the Registration Reference matches other information verified in accordance with section 11;
 3. take appropriate measures to disambiguate between different organizations as described in Appendix H for each Registration Scheme;
 4. Apply the validation rules relevant to the Registration Scheme as specified in Appendix H.
 
@@ -591,7 +590,7 @@ This section sets forth minimum requirements for the contents of EV Certificates
 
 Each EV Certificate issued by the CA to a Subscriber MUST contain a policy identifier that is either defined by these Guidelines or the CA in the certificate's certificatePolicies extension that:  (i) indicates which CA policy statement relates to that Certificate, (ii) asserts the CA's adherence to and compliance with these Guidelines, and (iii) is either the CA/Browser Forum’s EV policy identifier or a policy identifier that, by pre-agreement with the Application Software Supplier, marks the Certificate as being an EV Certificate.
 
-The following Certificate Policy identifier is the CA/Browser Forum’s EV policy identifier: 
+The following Certificate Policy identifier is the CA/Browser Forum’s EV policy identifier:
 {joint‐iso‐itu‐t(2) international‐organizations(23) ca‐browser‐forum(140) certificate‐policies(1) ev-guidelines (1) } (2.23.140.1.1), if the Certificate complies with these Guidelines.
 
 ### 9.3.3.  Root CA Certificates
@@ -610,7 +609,7 @@ A Certificate issued to a Subscriber MUST contain one or more policy identifier(
 
 ## 9.4.  Maximum Validity Period For EV Certificate
 
-The Validity Period for an EV Certificate SHALL NOT exceed 825 days. 
+The Validity Period for an EV Certificate SHALL NOT exceed 825 days.
 Effective 2020-09-01, the Validity Period for an EV Certificate SHALL NOT exceed 398 days.
 
 It is RECOMMENDED that EV Subscriber Certificates have a Maximum Validity Period of twelve months.
@@ -627,7 +626,7 @@ The requirements in Section 7.1 of the Baseline Requirements apply equally to EV
 
 All provisions of the Baseline Requirements concerning Minimum Cryptographic Algorithms, Key Sizes, and Certificate Extensions apply to EV Certificates with the following exceptions:
 
-(1)  If a Subordinate CA Certificates is issued to a Subordinate CA not controlled by the entity that controls the Root CA, the policy identifiers in the certificatePolicies extension MUST include the CA's Extended Validation policy identifier. 
+(1)  If a Subordinate CA Certificates is issued to a Subordinate CA not controlled by the entity that controls the Root CA, the policy identifiers in the certificatePolicies extension MUST include the CA's Extended Validation policy identifier.
 
 Otherwise, it MAY contain the anyPolicy identifier.
 
@@ -655,11 +654,11 @@ Otherwise, it MAY contain the anyPolicy identifier.
 
     - HTTP URL for the Subordinate CA's Certification Practice Statement
 
-(4)  The cRLDistribution Point extension MUST be present in Subscriber Certificates if the certificate does not specify OCSP responder locations in an authorityInformationAccess extension.
+(4)  The cRLDistributionPoints extension MUST be present in Subscriber Certificates if the certificate does not specify OCSP responder locations in an authorityInformationAccess extension.
 
 ## 9.8. Certificate Extensions
 
-The extensions listed in the Section 9.8 are recommended for maximum interoperability between certificates and browsers / applications, but are not mandatory on the CAs except where indicated as “Required”.  CAs may use other extensions that are not listed in this Section 9.8, but are encouraged to add them to this section by ballot from time to time to help increase externsion standardization across the industry.  
+The extensions listed in the Section 9.8 are recommended for maximum interoperability between certificates and browsers / applications, but are not mandatory on the CAs except where indicated as “Required”.  CAs may use other extensions that are not listed in this Section 9.8, but are encouraged to add them to this section by ballot from time to time to help increase extension standardization across the industry.  
 
 If a CA includes an extension in a certificate that has a Certificate field which is named in this Section 9.8, the CA must follow the format specified in that subjection.  However, no extension or extension format shall be mandatory on a CA unless specifically stated as “Required” in the subsection that describes the extension.
 
@@ -671,15 +670,15 @@ If a CA includes an extension in a certificate that has a Certificate field whic
 
 **Contents:** This extension MUST contain one or more host Domain Name(s) owned or controlled by the Subject and to be associated with the Subject's server.  Such server MAY be owned and operated by the Subject or another entity (e.g., a hosting service).  Wildcard certificates are not allowed for EV Certificates.
 
-### 9.8.2 CA/Browser Form Organization Identifier Extension
+### 9.8.2. CA/Browser Forum Organization Identifier Extension
 
 **Extension Name:** _cabfOrganizationIdentifier_ (OID: 2.23.140.3.1)
 
 **Verbose OID:** {joint-iso-itu-t(2) international-organizations(23) ca-browser-forum(140) certificate-extensions(3) cabf-organization-identifier(1) }
-              
+
 **Required/Optional:** Optional (but see below)
 
-**Contents:** If the subject:organizationIdentifier is present, this field SHOULD be present. Effective January 31, 2020, if the subject:organizationIdentifier field is present, this field MUST be present.
+**Contents:** If the subject:organizationIdentifier is present, this field MUST be present.
 
 If present, this extension MUST contain a Registration Reference for a Legal Entity assigned in accordance to the identified Registration Scheme.
 
@@ -697,7 +696,7 @@ The Registration Scheme MUST be encoded as described by the following ASN.1 gram
 >            registrationReference UTF8String
 >        }
 
-where the subfields have the same meanings and restrictions described in Section 9.2.8. The CA SHALL validate the contents using the requirements in Section 9.2.8.
+where the subfields have the same values, meanings, and restrictions described in Section 9.2.8. The CA SHALL validate the contents using the requirements in Section 9.2.8.
 
 # 10. EV Certificate Request Requirements
 
@@ -715,7 +714,7 @@ The following Applicant roles are required for the issuance of an EV Certificate
 
 (2)  **Certificate Approver:**  The EV Certificate Request MUST be approved by an authorized Certificate Approver.  A Certificate Approver is a natural person who is either the Applicant, employed by the Applicant, or an authorized agent who has express authority to represent the Applicant to (i) act as a Certificate Requester and to authorize other employees or third parties to act as a Certificate Requester, and (ii) to approve EV Certificate Requests submitted by other Certificate Requesters.
 
-(3)  **Contract Signer:**  Subcriber Agreement applicable to the requested EV Certificate MUST be signed by an authorized Contract Signer.  A Contract Signer is a natural person who is either the Applicant, employed by the Applicant, or an authorized agent who has express authority to represent the Applicant, and who has authority on behalf of the Applicant to sign Subscriber Agreements.
+(3)  **Contract Signer:**  A Subscriber Agreement applicable to the requested EV Certificate MUST be signed by an authorized Contract Signer.  A Contract Signer is a natural person who is either the Applicant, employed by the Applicant, or an authorized agent who has express authority to represent the Applicant, and who has authority on behalf of the Applicant to sign Subscriber Agreements.
 
 (4)   **Applicant Representative:**   In the case where the CA and the Subscriber are affiliated, Terms of Use applicable to the requested EV Certificate MUST be acknowledged and agreed to by an authorized Applicant Representative.  An Applicant Representative is a natural person who is either the Applicant, employed by the Applicant, or an authorized agent who has express authority to represent the Applicant, and who has authority on behalf of the Applicant to acknowledge and agree to the Terms of Use.
 
@@ -769,7 +768,7 @@ Effective as of 1 October 2020, prior to the use of an Incorporating Agency or R
 
 This Agency Information SHALL include at least the following:
 * Sufficient information to unambiguously identify the Incorporating Agency or Registration Agency (such as a name, jurisdiction, and website); and,
-* The accepted value or values for each of the `subject:jurisdictionLocalityName` (OID: 1.3.6.1.4.1.311.60.2.1.1), `subject:jurisdictionStateOrProvinceName` (OID: 1.3.6.1.4.1.311.60.2.1.2), and `subject:jursidictionCountryName` (OID: 1.3.6.1.4.1.311.60.2.1.3) fields, when a certificate is issued using information from that Incorporating Agency or Registration Agency, indicating the jurisdiction(s) that the Agency is appropriate for; and,
+* The accepted value or values for each of the `subject:jurisdictionLocalityName` (OID: 1.3.6.1.4.1.311.60.2.1.1), `subject:jurisdictionStateOrProvinceName` (OID: 1.3.6.1.4.1.311.60.2.1.2), and `subject:jurisdictionCountryName` (OID: 1.3.6.1.4.1.311.60.2.1.3) fields, when a certificate is issued using information from that Incorporating Agency or Registration Agency, indicating the jurisdiction(s) that the Agency is appropriate for; and,
 * The acceptable form or syntax of Registration Numbers used by the Incorporating Agency or Registration Agency, if the CA restricts such Numbers to an acceptable form or syntax; and,
 * A revision history that includes a unique version number and date of publication for any additions, modifications, and/or removals from this list.
 
@@ -907,7 +906,7 @@ The Third-Party Validator performing the face-to-face validation MUST:
 
 ## 11.3.  Verification of Applicant's Legal Existence and Identity – Assumed Name
 
-### 11.3.1  Verification Requirements
+### 11.3.1.  Verification Requirements
 
 If, in addition to the Applicant's formal legal name, as recorded with the applicable Incorporating Agency or Registration Agency in the Applicant's Jurisdiction of Incorporation or Registration, the Applicant's identity, as asserted in the EV Certificate, is to contain any assumed name (also known as "doing business as", "DBA", or "d/b/a" in the US, and "trading as" in the UK) under which the Applicant conducts business, the CA MUST verify that:  (i) the Applicant has registered its use of the assumed name with the appropriate government agency for such filings in the jurisdiction of its Place of Business (as verified in accordance with these Guidelines), and (ii) that such filing continues to be valid.
 
@@ -953,7 +952,7 @@ To verify any assumed name under which the Applicant conducts business:
 
 (iv) For Applicants whose Place of Business is in the same country as the Applicant's Jurisdiction of Incorporation or Registration and where the QGIS used in Section 11.2 to verify legal existence contains a business address for the Applicant, the CA MAY rely on the address in the QGIS to confirm the Applicant's or a Parent/Subsidiary Company's address as listed in the EV Certificate Request, and MAY rely on the Applicant's representation that such address is its Place of Business.
 
-(B) **Place of Business not in the Country of Incorporation or Registration:  ** The CA MUST rely on a Verified Professional Letter that indicates the address of the Applicant's Place of Business and that business operations are conducted there.
+(B) **Place of Business not in the Country of Incorporation or Registration:** The CA MUST rely on a Verified Professional Letter that indicates the address of the Applicant's Place of Business and that business operations are conducted there.
 
 ## 11.5. Verified Method of Communication
 
@@ -1041,7 +1040,7 @@ Acceptable methods of verification of the Signing Authority of the Contract Sign
 
 (4) **Contract between CA and Applicant:**  The EV Authority of the Certificate Approver MAY be verified by reliance on a contract between the CA and the Applicant that designates the Certificate Approver with such EV Authority, provided that the contract is signed by the Contract Signer and provided that the agency and Signing Authority of the Contract Signer have been verified;
 
-(5) **Prior Equivalent Authority:**  The signing authority of the Contract Signer,and/or the EV authority of the Certificate Approver, MAY be verified by relying on a demonstration of Prior Equivalent Authority.
+(5) **Prior Equivalent Authority:**  The signing authority of the Contract Signer, and/or the EV authority of the Certificate Approver, MAY be verified by relying on a demonstration of Prior Equivalent Authority.
 
 (A) Prior Equivalent Authority of a Contract Signer MAY be relied upon for confirmation or verification of the signing authority of the Contract Signer when the Contract Signer has executed a binding contract between the CA and the Applicant with a legally valid and enforceable seal or handwritten signature and only when the contract was executed more than 90 days prior to the EV Certificate application.  The CA MUST record sufficient details of the previous agreement to correctly identify it and associate it with the EV application.  Such details MAY include any of the following:
 
@@ -1153,7 +1152,7 @@ In circumstances where the opinion is digitally signed, in a manner that confirm
 
 ### 11.11.2.  Verified Accountant Letter
 
-(1)  **Verification Requirements:  ** Before relying on an accountant letter submitted to the CA, the CA MUST verify that such accountant letter meets the following requirements:
+(1)  **Verification Requirements:** Before relying on an accountant letter submitted to the CA, the CA MUST verify that such accountant letter meets the following requirements:
 
  (A) **Status of Author:**  The CA MUST verify that the accountant letter is authored by an Accounting Practitioner retained or employed by the Applicant and licensed within the country of the Applicant's Jurisdiction of Incorporation, Jurisdiction of Registration, or country where the Applicant maintains an office or physical facility.  Verification of license MUST be  through the member organization or regulatory organization in the Accounting Practitioner's country or jurisdiction that is appropriate to contact when verifying an accountant's license to practice in that country or jurisdiction.  Such country or jurisdiction must have an accounting standards body that maintains full membership status with the International Federation of Accountants.
 
@@ -1259,13 +1258,13 @@ A Qualified Government Tax Information Source is a Qualified Government Informat
 
 The High Risk Certificate requirements of Section 4.2.1 of the Baseline Requirements apply equally to EV Certificates.
 
-### 11.12.2.  Denied Lists and Other Legal Black Lists
+### 11.12.2.  Denied Lists and Other Legal Block Lists
 
 (1)  **Verification Requirements:**  The CA MUST verify whether the Applicant, the Contract Signer, the Certificate Approver, the Applicant's Jurisdiction of Incorporation, Registration, or Place of Business:
 
 (A)  Is identified on any government denied list, list of prohibited persons, or other list that prohibits doing business with such organization or person under the laws of the country of the CA's jurisdiction(s) of operation; or
 
-(B)  Has its Jurisdiction of Incorporation, Registration, orPlace of Business in any country with which the laws of the CA's jurisdiction prohibit doing business.
+(B)  Has its Jurisdiction of Incorporation, Registration, or Place of Business in any country with which the laws of the CA's jurisdiction prohibit doing business.
 
 The CA MUST NOT issue any EV Certificate to the Applicant if either the Applicant, the Contract Signer, or Certificate Approver or if the Applicant's Jurisdiction of Incorporation or Registration or Place of Business is on any such list.
 
@@ -1273,11 +1272,11 @@ The CA MUST NOT issue any EV Certificate to the Applicant if either the Applican
 
 (A) If the CA has operations in the U.S., the CA MUST take reasonable steps to verify with the following US Government denied lists and regulations:
 
-(i) BIS Denied Persons List - http://www.bis.doc.gov/dpl/thedeniallist.asp
+(i) BIS Denied Persons List - https://www.bis.doc.gov/index.php/the-denied-persons-list
 
-(ii) BIS Denied Entities List - http://www.bis.doc.gov/Entities/Default.htm
+(ii) BIS Denied Entities List - https://www.bis.doc.gov/index.php/policy-guidance/lists-of-parties-of-concern/entity-list
 
-(iii) US Treasury Department List of Specially Designated Nationals and Blocked Persons - http://www.treas.gov/ofac/t11sdn.pdf
+(iii) US Treasury Department List of Specially Designated Nationals and Blocked Persons - https://www.treasury.gov/resource-center/sanctions/sdn-list/pages/default.aspx
 
 (iv) US Government export regulations
 
@@ -1423,7 +1422,7 @@ The requirements in Section 5.3.3 of the Baseline Requirements apply equally to 
 
 ### 14.2.1.  General
 
-The CA MAY delegate the performance of all or any part of a requirement of these Guidelines to an Affiliate or a Registration Authority (RA) or subcontractor, provided that the process employed by the CA fulfills all of the requirements of Section 11.13. 
+The CA MAY delegate the performance of all or any part of a requirement of these Guidelines to an Affiliate or a Registration Authority (RA) or subcontractor, provided that the process employed by the CA fulfills all of the requirements of Section 11.13.
 Affiliates and/or RAs must comply with the qualification requirements of Section 14.1 of these Guidelines.
 
 The CA SHALL verify that the Delegated Third Party's personnel involved in the issuance of a Certificate meet the training and skills requirements of Section 14 and the document retention and event logging requirements of Section 15.
@@ -1464,9 +1463,9 @@ As specified in Section 5 of the Baseline Requirements. In addition, systems use
 
 A CA issuing EV Certificates SHALL undergo an audit in accordance with one of the following schemes:
 
- (i) WebTrust Program for CAs audit and WebTrust EV Program audit, 
- (ii) ETSI TS 102 042 audit for EVCP, or 
- (iii) ETSI EN 319 411-1 audit for EVCP policy. 
+ (i) WebTrust Program for CAs audit and WebTrust EV Program audit,
+ (ii) ETSI TS 102 042 audit for EVCP, or
+ (iii) ETSI EN 319 411-1 audit for EVCP policy.
 
 If the CA is a Government Entity, an audit of the CA by the appropriate internal government auditing agency is acceptable in lieu of the audits specified above, provided that such internal government auditing agency publicly certifies in writing that its audit addresses the criteria specified in one of the above audit schemes and certifies that the government CA has successfully passed the audit.
 
@@ -1549,7 +1548,7 @@ On this basis, we hereby offer the following opinion:
 
 3. That _[name of Client's Representative]_ /#2 has authority to act on behalf of Company to:  [_select as appropriate_] (a) provide the information about Company required for issuance of the EV Certificates as contained in the attached Application, (b) request one or more EV Certificates and to designate other persons to request EV Certificates, and (c) agree to the relevant contractual obligations contained in the Subscriber Agreement on behalf of Company.
 
-4. That Company has a physical presence and its place of business is at the following location: 
+4. That Company has a physical presence and its place of business is at the following location:
 
 5. That Company can be contacted at its stated place of business at the following telephone number:
 
@@ -1576,8 +1575,8 @@ Footnote /#1:  This must be the Client's exact corporate name, as registered wit
 Footnote /#2:  If necessary to establish the Client Representative's actual authority, you may rely on a Power of Attorney from an officer of Client who has authority to delegate the authority to the Client Representative.
 
 Footnote /#3:  This letter may be issued by in-house counsel for the Client so long as permitted by the rules of your jurisdiction.
- 
- 
+
+
 # Appendix C - Sample Accountant Letters Confirming Specified Information
 
 **(Informative)**
@@ -1658,7 +1657,7 @@ NOTE:  This appendix provides alternative interpretations of the EV Guidelines f
 
 (1) Non-Latin Organization Name
 
-Where an EV Applicant's organization name is not registered with a QGIS in _Latin _characters and the Applicant's foreign character organization name and registration have been verified with a QGIS in accordance with these Guidelines, a CA MAY include a Latin character organization name in the EV Certificate.  In such a case, the CA MUST follow the procedures laid down in this section.
+Where an EV Applicant's organization name is not registered with a QGIS in _Latin_ characters and the Applicant's foreign character organization name and registration have been verified with a QGIS in accordance with these Guidelines, a CA MAY include a Latin character organization name in the EV Certificate.  In such a case, the CA MUST follow the procedures laid down in this section.
 
 (2) Romanized Names
 
@@ -1684,7 +1683,7 @@ In order to include a Latin character name in the EV certificate that is not a d
 
 (D) Confirmed by a Verified Legal Opinion or Accountant's Letter to be a translated trading name associated with the registered organization.
 
-# Country-Specific Procedures
+## D.1. Country-Specific Procedures
 
 **D-1. Japan**
 
@@ -1746,7 +1745,7 @@ A CA may issue an EV Certificate with .onion in the right-most label of the Doma
 
 1. CAB Forum Tor Service Descriptor Hash extension (2.23.140.1.31)
 
-The CA MUST include the CAB Forum Tor Service Descriptor Hash extension in the TBSCertificate to convey hashes of keys related to .onion addresses. The CA MUST include the Tor Service Descriptor Hash extension using the following format: 
+The CA MUST include the CAB Forum Tor Service Descriptor Hash extension in the TBSCertificate to convey hashes of keys related to .onion addresses. The CA MUST include the Tor Service Descriptor Hash extension using the following format:
 
 ```
 cabf-TorServiceDescriptor OBJECT IDENTIFIER ::= { 2.23.140.1.31 }
@@ -1764,7 +1763,7 @@ TorServiceDescriptorHash:: = SEQUENCE {
 
 }
 ```
-Where the AlgorithmIdentifier is a hashing algorithm (defined in RFC 6234) performed over the DER-encoding of an ASN.1 SubjectPublicKey of the .onion service and SubjectPublicKeyHash is the hash output.
+Where the AlgorithmIdentifier is a hashing algorithm (defined in RFC 6234) performed over the DER-encoding of an ASN.1 subjectPublicKey of the .onion service and subjectPublicKeyHash is the hash output.
 
 2. The CA MUST verify the Applicant's control over the .onion Domain Name using one of the following:
 
@@ -1811,7 +1810,7 @@ cabf-applicantSigningNonce OBJECT IDENTIFIER ::= { cabf 42 }
 
 #  Appendix G – Abstract Syntax Notation One module for EV certificates
 
-``` 
+```
 CABFSelectedAttributeTypes {joint‐iso‐itu‐t(2) international‐organizations(23) ca‐browser‐forum(140) module(4) cabfSelectedAttributeTypes(1) 1}
 DEFINITIONS ::=
 BEGIN
@@ -1847,7 +1846,7 @@ jurisdictionStateOrProvinceName ATTRIBUTE ::= {
   LDAP-SYNTAX              directoryString.&id
   LDAP-NAME                {"jurisdictionST"}
   ID                       id-evat-jurisdiction-stateOrProvinceName }
-  
+
 jurisdictionCountryName ATTRIBUTE ::= {
   SUBTYPE OF               name
   WITH SYNTAX              CountryName
@@ -1861,33 +1860,33 @@ END
 
 #  Appendix H – Registration Schemes
 
-The following Registration Schemes are currently recognised as valid under these 
+The following Registration Schemes are currently recognized as valid under these
 guidelines:
 
-**NTR**: The information carried in this field shall be the same as held in Subject 
-   Registration Number Field as specified in 9.2.5 and the country code used in 
-   the Registration Scheme identifier shall match that of the subject’s jurisdiction 
+**NTR**: The information carried in this field shall be the same as held in Subject
+   Registration Number Field as specified in 9.2.5 and the country code used in
+   the Registration Scheme identifier shall match that of the subject’s jurisdiction
    as specified in Section 9.2.4.
 
-   Where the Subject Jurisdiction of Incorporation or Registration Field in 9.2.4 
+   Where the Subject Jurisdiction of Incorporation or Registration Field in 9.2.4
    includes more than the country code, the additional locality information shall
-   be included as specified in sections 9.2.8 and/or 9.8.1.
+   be included as specified in sections 9.2.8 and/or 9.8.2.
 
-**VAT**: Reference allocated by the national tax authorities to a Legal Entity. This 
-   information shall be validated using information provided by the national tax 
-   authority against the organisation as identified by the Subject Organization 
-   Name Field (see 9.2.1) and Subject Registration Number Field (see 9.2.5) within 
+**VAT**: Reference allocated by the national tax authorities to a Legal Entity. This
+   information shall be validated using information provided by the national tax
+   authority against the organization as identified by the Subject Organization
+   Name Field (see 9.2.1) and Subject Registration Number Field (see 9.2.5) within
    the context of the subject’s jurisdiction as specified in Section 9.2.4.
-   
-**PSD**: Authorization number as specified in ETSI TS 119 495 clause 4.4 allocated to a 
-   payment service provider and containing the information as specified in 
-   ETSI TS 119 495 clause 5.2.1.  This information SHALL be obtained directly from the 
-   national competent authority register for payment services or from an information 
-   source approved by a government agency, regulatory body, or legislation for this 
-   purpose.  This information SHALL be validated by being matched directly or indirectly 
-   (for example, by matching a globally unique registration number) against the 
-   organisation as identified by the Subject Organization Name Field (see 9.2.1) and 
-   Subject Registration Number Field (see 9.2.5) within the context of the subject’s 
-   jurisdiction as specified in Section 9.2.4.  The stated address of the organisation 
-   combined with the organization name SHALL NOT be the only information used to 
-   disambiguate the organisation.
+
+**PSD**: Authorization number as specified in ETSI TS 119 495 clause 4.4 allocated to a
+   payment service provider and containing the information as specified in
+   ETSI TS 119 495 clause 5.2.1.  This information SHALL be obtained directly from the
+   national competent authority register for payment services or from an information
+   source approved by a government agency, regulatory body, or legislation for this
+   purpose.  This information SHALL be validated by being matched directly or indirectly
+   (for example, by matching a globally unique registration number) against the
+   organization as identified by the Subject Organization Name Field (see 9.2.1) and
+   Subject Registration Number Field (see 9.2.5) within the context of the subject’s
+   jurisdiction as specified in Section 9.2.4.  The stated address of the organization
+   combined with the organization name SHALL NOT be the only information used to
+   disambiguate the organization.


### PR DESCRIPTION
* Cleanup typos and issues from SC17

Closes https://github.com/cabforum/documents/issues/152

* Fix an incorrect reference from 3.2.5 to 3.2.2.5

Closes https://github.com/cabforum/documents/issues/155

* Fix typo: compliancy -> compliance

Closes https://github.com/cabforum/documents/issues/159

* Cleanup old effective date for CP/CPSes

Closes https://github.com/cabforum/documents/issues/161

* Update effective date for 3.2.2.4.6

Closes https://github.com/cabforum/documents/issues/163

* Move weak key lookups into 24-hour revocation

Closes https://github.com/cabforum/documents/issues/164

* Align Section 6.1.1.3 with 4.9.1.1

Closes https://github.com/cabforum/documents/issues/171

* Replace RFC 6844 with RFC 8659

Closes https://github.com/cabforum/documents/issues/168

* Clarify that revocation is permitted if required by CP/CPS/BRs

Closes https://github.com/cabforum/documents/issues/172

* Correct links to US gov't denial lists

Closes https://github.com/cabforum/documents/issues/76

* Add a definition for CA Key Pair

https://github.com/cabforum/documents/issues/127

* Clarify CA Key Pair generation (#23)

Close https://github.com/cabforum/documents/issues/184

* Attempt to clarify policy OIDs (#21)

Attempts to resolve https://github.com/cabforum/documents/issues/179 by introducing the term "Server Certificate" to distinguish from Subscriber Certificate (which may include Subordinate CAs), and to scope the requirements around identity information to only Server Certificates

* Fixup formatting issues in the PDF

* Fix issues spotted by Corey

Co-authored-by: Corey Bonnell <corey.j.bonnell@outlook.com>

* Cleanup EVG terminology

* Clarify organizationIdentifier contents

As requested by Mads from Buypass in https://archive.cabforum.org/pipermail/servercert-wg/2020-August/002148.html

* Apply further suggestions from Corey

Correct Subscriber -> Applicant in additional places

Co-authored-by: Corey Bonnell <corey.j.bonnell@outlook.com>

* Spelling, formatting, punctuation improvements (#31)

* Where a word was spelling multiple ways (e.g. organization & organisation) consolidate on whichever form is the majority used
* MD formatting improvements (e.g. 5 numeral headings updated to have 5 '#' instead of 4)
* More consistent punctuation in section headings (e.g. '3.2.2.4.*:' vs '3.2.2.4.*')
* More correct - I hope - extension values (e.g. extKeyUsage instead of extendedKeyUsage)
* Improved, but identical - I hope - terminology (e.g. key purposes instead of usages where context is id-kp-*)
* Various minor spelling corrections (e.g. jursidiction -> jurisdiction, Certifiation -> Certification, etc.)

Co-authored-by: Corey Bonnell <corey.j.bonnell@outlook.com>
Co-authored-by: Clint Wilson <clint@wilsonovi.com>