### PR TITLE
Correct the reasons for not needing the AIA in OCSP certificates

### DIFF
--- a/docs/BR.md
+++ b/docs/BR.md
@@ -2565,7 +2565,7 @@ If the Issuing CA does not directly sign OCSP responses, it MAY make use of an O
 
 ##### 7.1.2.8.3 OCSP Responder Authority Information Access
 
-For OCSP Responder certificates, this extension is NOT RECOMMENDED, as the Relying Party should already possess the necessary information. In order to validate the given Responder certificate, the Relying Party must have access to the Issuing CA's certificate, eliminating the need to provide `id-ad-caIssuers`. Similarly, because of the requirement for an OCSP Responder certificate to include the `id-pkix-ocsp-nocheck` extension, it is not necessary to provide `id-ad-ocsp`, as such responses will not be checked by Relying Parties.
+For OCSP Responder certificates, this extension is NOT RECOMMENDED, as the Relying Party should already possess the necessary information. In order to perform the OCSP request in the first place, the Relying Party usually needs access to the Issuing CA's certificate, eliminating the need to provide `id-ad-caIssuers`. Similarly, because of the requirement for an OCSP Responder certificate to include the `id-pkix-ocsp-nocheck` extension, it is not necessary to provide `id-ad-ocsp`, as such OCSP Responder certificates will not be checked by Relying Parties.
 
 If present, the `AuthorityInfoAccessSyntax` MUST contain one or more `AccessDescription`s. Each `AccessDescription` MUST only contain a permitted `accessMethod`, as detailed below, and each `AuthorityInfoAccessSyntax` MUST contain all required `AccessDescription`s.
 


### PR DESCRIPTION
From https://datatracker.ietf.org/doc/html/rfc6960#section-4.1.1:

> 4.1.1.  ASN.1 Specification of the OCSP Request
> ...
> CertID          ::=     SEQUENCE {
>        hashAlgorithm       AlgorithmIdentifier,
>        issuerNameHash      OCTET STRING, -- Hash of issuer's DN
>        issuerKeyHash       OCTET STRING, -- Hash of issuer's public key
>        serialNumber        CertificateSerialNumber }
> ...
> The contents of CertID include the following fields:
> ...
>    o  issuerNameHash is the hash of the issuer's distinguished name
>       (DN).  The hash shall be calculated over the DER encoding of the
>       issuer's name field in the certificate being checked.
>    o  issuerKeyHash is the hash of the issuer's public key.  The hash
>       shall be calculated over the value (excluding tag and length) of
>       the subject public key field in the issuer's certificate.
>    o  serialNumber is the serial number of the certificate for which
>       status is being requested.

From https://datatracker.ietf.org/doc/html/rfc6960#section-4.2.2.2.1:

> 4.2.2.2.1.  Revocation Checking of an Authorized Responder
> ...
> - A CA may specify that an OCSP client can trust a responder for the
>      lifetime of the responder's certificate.  The CA does so by
>      including the extension id-pkix-ocsp-nocheck.