### PR TITLE
SC-101v2: Clarify Authorization Domain Names

### DIFF
--- a/docs/BR.md
+++ b/docs/BR.md
@@ -754,7 +754,7 @@ The CA MUST follow this process when choosing the Authorization Domain Name "ADN
 2. Choose a validation method. If `A` is a Wildcard Domain Name, the CA MUST choose a validation method that allows wildcard issuance. If `A` is an Onion Domain Name, the CA MUST choose a validation method that allows Onion Domain Name issuance.
 3. If `A` is an FQDN, choose at most one:
   a. If the validation method allows CNAME lookups when choosing the ADN, replace `A` with the result of a DNS CNAME lookup of `A`.
-  c. If the validation method allows pruning domain labels when choosing the ADN, prune zero or more Domain Labels of `A` from left to right until encountering the Base Domain Name of `A` or the CA chooses to stop pruning, whichever comes first.
+  b. If the validation method allows pruning domain labels when choosing the ADN, prune zero or more Domain Labels of `A` from left to right until encountering the Base Domain Name of `A` or the CA chooses to stop pruning, whichever comes first.
 4. If `A` is a Wildcard Domain Name:
   a. Remove "\*." from the left-most portion of `A`.
   b. If the validation method allows pruning domain labels when choosing the ADN, prune zero or more Domain Labels of `A` from left to right until encountering the Base Domain Name of `A` or the CA chooses to stop pruning, whichever comes first.

--- a/docs/BR.md
+++ b/docs/BR.md
@@ -851,8 +851,6 @@ CAs performing validations using this method MUST implement Multi-Perspective Is
 
 If the CA or an Affiliate of the CA operates a DNS zone to which Applicants can delegate (via CNAME) their underscore-prefixed Domain Label, the CA MUST ensure that each Applicant delegates to a unique FQDN within that zone. A CA or Affiliate of a CA SHOULD NOT operate such a service, and SHOULD direct any Applicants using such a service to use the method described in [Section 3.2.2.4.22](#322422-dns-txt-record-with-persistent-value) instead.
 
-**Note**: Once the FQDN has been validated using this method, the CA MAY also issue Certificates for other FQDNs that end with all the Domain Labels of the validated FQDN. This method is suitable for validating Wildcard Domain Names.
-
 ##### 3.2.2.4.8 IP Address
 
 Confirming the Applicant's control over the ADN by confirming that the Applicant controls an IP address returned from a DNS lookup for A or AAAA records for the ADN in accordance with [Section 3.2.2.5](#3225-authentication-for-an-ip-address).
@@ -997,9 +995,7 @@ CAs performing validations using this method MUST implement Multi-Perspective Is
 
 ##### 3.2.2.4.22 DNS TXT Record with Persistent Value
 
-Confirming the Applicant's control over a FQDN by verifying the presence of a Persistent DCV TXT Record identifying the Applicant. The record MUST be placed at the "`_validation-persist`" label prepended to the Authorization Domain Name being validated (i.e., "`_validation-persist.[Authorization Domain Name]`"). For this method, the CA MUST NOT use the FQDN returned from a DNS CNAME lookup as the FQDN for the purposes of domain validation. This prohibition overrides the Authorization Domain Name definition. CNAME records MAY be followed when resolving the Persistent DCV TXT Record.
-
-The CA MUST confirm the Persistent DCV TXT Record’s RDATA value fulfills the following requirements:
+Confirming the Applicant's control over the ADN by verifying the presence of a Persistent DCV TXT Record identifying the Applicant. The record MUST be placed at the "`_validation-persist`" label prepended to the Authorization Domain Name being validated (i.e., "`_validation-persist.[Authorization Domain Name]`"). This prohibition overrides the Authorization Domain Name definition.
 
 1. The RDATA value MUST conform to the `issue-value` syntax as defined in RFC 8659, Section 4.2; and
 2. The `issuer-domain-name` value MUST be an Issuer Domain Name disclosed by the CA in Section 4.2 of the CA's Certificate Policy and/or Certification Practices Statement; and
@@ -1025,8 +1021,6 @@ Table: Examples of how the `persistUntil` parameter affects validation
 | 2025-06-15T12:00:00Z | (not present) | Yes | No persistUntil parameter present, so no time restriction applies |
 
 CAs performing validations using this method MUST implement Multi-Perspective Issuance Corroboration as specified in [Section 3.2.2.9](#3229-multi-perspective-issuance-corroboration). To count as corroborating, a Network Perspective MUST observe a Persistent DCV TXT Record that demonstrates the Applicant's control over the domain and contains the same `accounturi` parameter as the Primary Network Perspective.
-
-**Note**: Once the FQDN has been validated using this method, the CA MAY also issue Certificates for other FQDNs that end with all the Domain Labels of the validated FQDN. This method is suitable for validating Wildcard Domain Names.
 
 #### 3.2.2.5 Authentication for an IP Address
 

--- a/docs/BR.md
+++ b/docs/BR.md
@@ -757,7 +757,7 @@ The CA MUST follow this process when choosing the Authorization Domain Name "ADN
 1. Initialize `A` to the applied-for FQDN or Wildcard Domain Name.
 2. Choose a validation method. If `A` is a Wildcard Domain Name, the CA MUST choose a validation method with a check in the Wildcard column below. If `A` is an Onion Domain Name, the CA MUST choose a validation method with a check in the Onion column below.
 3. If `A` is an FQDN:
-    1. Optionally, if the validation method has a check in the CNAME column below, replace `A` with the result of a DNS CNAME lookup of `A`.
+    1. Optionally, if the validation method has a check in the CNAME column below, replace `A` with the result of a DNS CNAME lookup of `A`. This step may be repeated.
     2. If the validation method has a check in the Prune column below, prune zero or more Domain Labels of `A` from left to right until `A` is equal to the Base Domain Name of `A`, or the CA chooses to stop pruning, whichever comes first.
 4. If `A` is a Wildcard Domain Name:
     1. Remove "\*." from the left-most portion of `A`.

--- a/docs/BR.md
+++ b/docs/BR.md
@@ -751,13 +751,30 @@ This section defines the permitted processes and procedures for validating the A
 The CA MUST follow this process when choosing the Authorization Domain Name "ADN" for validation of each applied-for FQDN or Wildcard Domain Name:
 
 1. Initialize `A` to the applied-for FQDN or Wildcard Domain Name.
-2. Choose a validation method. If `A` is a Wildcard Domain Name, the CA MUST choose a validation method that allows wildcard issuance. If `A` is an Onion Domain Name, the CA MUST choose a validation method that allows Onion Domain Name issuance.
+2. Choose a validation method. If `A` is a Wildcard Domain Name, the CA MUST choose a validation method with a check in the Wildcard column below. If `A` is an Onion Domain Name, the CA MUST choose a validation method with a check in the Onion column below.
 3. If `A` is an FQDN:
-    1. Optionally, if the validation method allows CNAME lookups when choosing the ADN, replace `A` with the result of a DNS CNAME lookup of `A`.
-    2. If the validation method allows pruning domain labels when choosing the ADN, prune zero or more Domain Labels of `A` from left to right until `A` is equal to the Base Domain Name of `A`, or the CA chooses to stop pruning, whichever comes first.
+    1. Optionally, if the validation method has a check in the CNAME column below, replace `A` with the result of a DNS CNAME lookup of `A`.
+    2. If the validation method has a check in the Prune column below, prune zero or more Domain Labels of `A` from left to right until `A` is equal to the Base Domain Name of `A`, or the CA chooses to stop pruning, whichever comes first.
 4. If `A` is a Wildcard Domain Name:
     1. Remove "\*." from the left-most portion of `A`.
-    2. If the validation method allows pruning domain labels when choosing the ADN, prune zero or more Domain Labels of `A` from left to right until `A` is equal to the Base Domain Name of `A`, or the CA chooses to stop pruning, whichever comes first.
+    2. If the validation method has a check in the Prune column below, prune zero or more Domain Labels of `A` from left to right until `A` is equal to the Base Domain Name of `A`, or the CA chooses to stop pruning, whichever comes first.
+5. Use `A` as the ADN.
+
+| Method                                         | Wildcard | Prune | CNAME | Onion |
+| --------                                                    | - | - | - | - |
+| 3.2.2.4.4 Constructed Email to Domain Contact               | ✔️ | ✔️ | ✔️ | - |
+| 3.2.2.4.7 DNS Change                                        | ✔️ | ✔️ | ✔️ | - |
+| 3.2.2.4.8 IP Address                                        | - | - | - | - |
+| 3.2.2.4.12 Validating Applicant as a Domain Contact         | ✔️ | ✔️ | - | - |
+| 3.2.2.4.13 Email to DNS CAA Contact                         | ✔️ | ✔️ | ✔️ | - |
+| 3.2.2.4.14 Email to DNS TXT Contact                         | ✔️ | ✔️ | ✔️ | - |
+| 3.2.2.4.16 Phone Contact with DNS TXT Record Phone Contact  | ✔️ | ✔️ | ✔️ | - |
+| 3.2.2.4.17 Phone Contact with DNS CAA Phone Contact         | ✔️ | ✔️ | ✔️ | - |
+| 3.2.2.4.18 Agreed-Upon Change to Website v2                 | - | - | - | ✔️ |
+| 3.2.2.4.19 Agreed-Upon Change to Website - ACME             | - | - | - | ✔️ |
+| 3.2.2.4.20 TLS Using ALPN                                   | - | - | - | ✔️ |
+| 3.2.2.4.21 DNS Labeled with Account ID - ACME               | ✔️ | ✔️ | - | - |
+| Appendix B.2.b                                              | ✔️ | ✔️ | - | ✔️ |
 
 When the ADN is an Onion Domain Name, the CA SHALL validate it in accordance with Appendix B.
 
@@ -806,12 +823,6 @@ The email MAY be re-sent in its entirety, including the re-use of the Random Val
 
 The Random Value SHALL remain valid for use in a confirming response for no more than 30 days from its creation. The CPS MAY specify a shorter validity period for Random Values.
 
-This method allows wildcard issuance.
-
-This method allows pruning domain labels when choosing the ADN.
-
-This method allows CNAME lookups when choosing the ADN.
-
 ##### 3.2.2.4.5 Domain Authorization Document
 
 This method has been retired and MUST NOT be used. Prior validations using this method and validation data gathered according to this method SHALL NOT be used to issue certificates.
@@ -833,23 +844,11 @@ If a Random Value is used, the CA SHALL provide a Random Value unique to the Cer
 
 CAs performing validations using this method MUST implement Multi-Perspective Issuance Corroboration as specified in [Section 3.2.2.9](#3229-multi-perspective-issuance-corroboration). To count as corroborating, a Network Perspective MUST observe the same challenge information (i.e. Random Value or Request Token) as the Primary Network Perspective.
 
-This method allows wildcard issuance.
-
-This method allows pruning domain labels when choosing the ADN.
-
-This method does not allow CNAME lookups when choosing the ADN. Note: Domain name resolution includes processing of CNAMEs, so validation under this method naturally includes processing CNAMES, even when the DNS query type is TXT or CAA.
-
 ##### 3.2.2.4.8 IP Address
 
 Confirming the Applicant's control over the ADN by confirming that the Applicant controls an IP address returned from a DNS lookup for A or AAAA records for the ADN in accordance with [Section 3.2.2.5](#3225-authentication-for-an-ip-address).
 
 CAs performing validations using this method MUST implement Multi-Perspective Issuance Corroboration as specified in [Section 3.2.2.9](#3229-multi-perspective-issuance-corroboration). To count as corroborating, a Network Perspective MUST observe the same IP address as the Primary Network Perspective.
-
-This method MUST NOT be used for wildcard issuance.
-
-This method does not allow pruning domain labels when choosing the ADN.
-
-This method does not allow CNAME lookups when choosing the ADN.
 
 ##### 3.2.2.4.9 Test Certificate
 
@@ -869,12 +868,6 @@ Confirming the Applicant's control over the ADN by validating the Applicant is t
 
 The Domain Contact for an ADN is: The registrant, technical contact, or administrative contact (or the equivalent under a ccTLD) as listed in the WHOIS record of the ADN or as obtained through direct contact with the Domain Name Registrar, or the holder of the email address in an SOA record for the ADN.
 
-This method allows wildcard issuance.
-
-This method allows pruning domain labels when choosing the ADN.
-
-This method does not allow CNAME lookups when choosing the ADN.
-
 Effective January 15, 2025:
 - When issuing Subscriber Certificates, the CA MUST NOT rely on Domain Contact information obtained using an HTTPS website, regardless of whether previously obtained information is within the allowed reuse period.
 - When obtaining Domain Contact information for the ADN the CA:
@@ -892,12 +885,6 @@ The Random Value SHALL be unique in each email. The email MAY be re-sent in its 
 
 CAs performing validations using this method MUST implement Multi-Perspective Issuance Corroboration as specified in [Section 3.2.2.9](#3229-multi-perspective-issuance-corroboration). To count as corroborating, a Network Perspective MUST observe the same selected contact address used for domain validation as the Primary Network Perspective.
 
-This method allows wildcard issuance.
-
-This method allows pruning domain labels when choosing the ADN.
-
-This method allows CNAME lookups when choosing the ADN.
-
 ##### 3.2.2.4.14 Email to DNS TXT Contact
 
 Confirming the Applicant's control over the ADN by sending a Random Value via email and then receiving a confirming response utilizing the Random Value. The Random Value MUST be sent to a DNS TXT Record Email Contact for the Authorization Domain Name.
@@ -907,12 +894,6 @@ The same email MAY be sent to multiple recipients as long as all recipients are 
 The Random Value SHALL be unique in each email. The email MAY be re-sent in its entirety, including the re-use of the Random Value, provided that its entire contents and recipient(s) SHALL remain unchanged. The Random Value SHALL remain valid for use in a confirming response for no more than 30 days from its creation. The CPS MAY specify a shorter validity period for Random Values.
 
 CAs performing validations using this method MUST implement Multi-Perspective Issuance Corroboration as specified in [Section 3.2.2.9](#3229-multi-perspective-issuance-corroboration). To count as corroborating, a Network Perspective MUST observe the same selected contact address used for domain validation as the Primary Network Perspective.
-
-This method allows wildcard issuance.
-
-This method allows pruning domain labels when choosing the ADN.
-
-This method allows CNAME lookups when choosing the ADN.
 
 ##### 3.2.2.4.15 Phone Contact with Domain Contact
 
@@ -930,12 +911,6 @@ The Random Value SHALL remain valid for use in a confirming response for no more
 
 CAs performing validations using this method MUST implement Multi-Perspective Issuance Corroboration as specified in [Section 3.2.2.9](#3229-multi-perspective-issuance-corroboration). To count as corroborating, a Network Perspective MUST observe the same selected contact address used for domain validation as the Primary Network Perspective.
 
-This method allows wildcard issuance.
-
-This method allows pruning domain labels when choosing the ADN.
-
-This method allows CNAME lookups when choosing the ADN.
-
 ##### 3.2.2.4.17 Phone Contact with DNS CAA Phone Contact
 
 Confirm the Applicant's control over the ADN by calling the DNS CAA Phone Contact’s phone number and obtain a confirming response to validate the ADN. Each phone call MAY confirm control of multiple ADNs provided that the same DNS CAA Phone Contact phone number is listed for each ADN being verified and the recipient of the phone call provides a confirming response for each ADN. The relevant CAA Resource Record Set MUST be found using the search algorithm defined in RFC 8659 Section 3.
@@ -947,12 +922,6 @@ In the event of reaching voicemail, the CA may leave the Random Value and the AD
 The Random Value SHALL remain valid for use in a confirming response for no more than 30 days from its creation. The CPS MAY specify a shorter validity period for Random Values.
 
 CAs performing validations using this method MUST implement Multi-Perspective Issuance Corroboration as specified in [Section 3.2.2.9](#3229-multi-perspective-issuance-corroboration). To count as corroborating, a Network Perspective MUST observe the same selected contact address used for domain validation as the Primary Network Perspective.
-
-This method allows wildcard issuance.
-
-This method allows pruning domain labels when choosing the ADN.
-
-This method allows CNAME lookups when choosing the ADN.
 
 ##### 3.2.2.4.18 Agreed-Upon Change to Website v2
 
@@ -983,14 +952,6 @@ If a Random Value is used, then:
 
 Except for Onion Domain Names, CAs performing validations using this method MUST implement Multi-Perspective Issuance Corroboration as specified in [Section 3.2.2.9](#3229-multi-perspective-issuance-corroboration). To count as corroborating, a Network Perspective MUST observe the same challenge information (i.e. Random Value or Request Token) as the Primary Network Perspective.
 
-This method MUST NOT be used for wildcard issuance.
-
-This method does not allow pruning domain labels when choosing the ADN.
-
-This method does not allow CNAME lookups when choosing the ADN.
-
-This method allows Onion Domain Name issuance.
-
 ##### 3.2.2.4.19 Agreed-Upon Change to Website - ACME
 
 Confirming the Applicant's control over the ADN by validating domain control of the ADN using the ACME HTTP Challenge method defined in Section 8.3 of RFC 8555. The following are additive requirements to RFC 8555.
@@ -1009,14 +970,6 @@ If the CA follows redirects, the following apply:
 
 Except for Onion Domain Names, CAs performing validations using this method MUST implement Multi-Perspective Issuance Corroboration as specified in [Section 3.2.2.9](#3229-multi-perspective-issuance-corroboration). To count as corroborating, a Network Perspective MUST observe the same challenge information (i.e. token) as the Primary Network Perspective.
 
-This method MUST NOT be used for wildcard issuance.
-
-This method does not allow pruning domain labels when choosing the ADN.
-
-This method does not allow CNAME lookups when choosing the ADN.
-
-This method allows Onion Domain Name issuance.
-
 ##### 3.2.2.4.20 TLS Using ALPN
 
 Confirming the Applicant's control over the ADN by validating domain control of the ADN by negotiating a new application layer protocol using the TLS Application-Layer Protocol Negotiation (ALPN) Extension [RFC7301] as defined in RFC 8737. The following are additive requirements to RFC 8737.
@@ -1025,14 +978,6 @@ The token (as defined in RFC 8737, Section 3) MUST NOT be used for more than 30 
 
 Except for Onion Domain Names, CAs performing validations using this method MUST implement Multi-Perspective Issuance Corroboration as specified in [Section 3.2.2.9](#3229-multi-perspective-issuance-corroboration). To count as corroborating, a Network Perspective MUST observe the same challenge information (i.e. token) as the Primary Network Perspective.
 
-This method MUST NOT be used for wildcard issuance.
-
-This method does not allow pruning domain labels when choosing the ADN.
-
-This method does not allow CNAME lookups when choosing the ADN.
-
-This method allows Onion Domain Name issuance.
-
 ##### 3.2.2.4.21 DNS Labeled with Account ID - ACME
 
 Confirming the Applicant's control over the ADN by performing the procedure documented for a “dns-account-01” challenge in draft 00 of “Automated Certificate Management Environment (ACME) DNS Labeled With ACME Account ID Challenge,” available at [https://datatracker.ietf.org/doc/draft-ietf-acme-dns-account-label/](https://datatracker.ietf.org/doc/draft-ietf-acme-dns-account-label/).
@@ -1040,12 +985,6 @@ Confirming the Applicant's control over the ADN by performing the procedure docu
 The token (as defined in draft 00 of “Automated Certificate Management Environment (ACME) DNS Labeled With ACME Account ID Challenge,” Section 3.1) MUST NOT be used for more than 30 days from its creation. The CPS MAY specify a shorter validity period for the token, in which case the CA MUST follow its CPS.
 
 CAs performing validations using this method MUST implement Multi-Perspective Issuance Corroboration as specified in [Section 3.2.2.9](#3229-multi-perspective-issuance-corroboration). To count as corroborating, a Network Perspective MUST observe the same token as the Primary Network Perspective.
-
-This method allows wildcard issuance.
-
-This method allows pruning domain labels when choosing the ADN.
-
-This method does not allow CNAME lookups when choosing the ADN.
 
 #### 3.2.2.5 Authentication for an IP Address
 
@@ -4029,13 +3968,5 @@ This appendix defines permissible verification procedures for including one or m
       ```
 
       The Random Value SHALL remain valid for use in a confirming response for no more than 30 days from its creation. The CPS MAY specify a shorter validity period for Random Values.
-
-      This method allows wildcard issuance.
-
-      This method allows pruning domain labels when choosing the ADN.
-
-      This method does not allow CNAME lookups when choosing the ADN.
-
-      This method allows Onion Domain Name issuance.
 
 3. When a Certificate includes an Onion Domain Name, the Domain Name shall not be considered an Internal Name provided that the Certificate was issued in compliance with this [Appendix B](#appendix-b--issuance-of-certificates-for-onion-domain-names).

--- a/docs/BR.md
+++ b/docs/BR.md
@@ -753,11 +753,11 @@ The CA MUST follow this process when choosing the Authorization Domain Name "ADN
 1. Initialize `A` to the applied-for FQDN or Wildcard Domain Name.
 2. Choose a validation method. If `A` is a Wildcard Domain Name, the CA MUST choose a validation method that allows wildcard issuance. If `A` is an Onion Domain Name, the CA MUST choose a validation method that allows Onion Domain Name issuance.
 3. If `A` is an FQDN, choose at most one:
-    a. If the validation method allows CNAME lookups when choosing the ADN, replace `A` with the result of a DNS CNAME lookup of `A`.
-    b. If the validation method allows pruning domain labels when choosing the ADN, prune zero or more Domain Labels of `A` from left to right until encountering the Base Domain Name of `A` or the CA chooses to stop pruning, whichever comes first.
+    1. If the validation method allows CNAME lookups when choosing the ADN, replace `A` with the result of a DNS CNAME lookup of `A`.
+    2. If the validation method allows pruning domain labels when choosing the ADN, prune zero or more Domain Labels of `A` from left to right until encountering the Base Domain Name of `A` or the CA chooses to stop pruning, whichever comes first.
 4. If `A` is a Wildcard Domain Name:
-    a. Remove "\*." from the left-most portion of `A`.
-    b. If the validation method allows pruning domain labels when choosing the ADN, prune zero or more Domain Labels of `A` from left to right until encountering the Base Domain Name of `A` or the CA chooses to stop pruning, whichever comes first.
+    1. Remove "\*." from the left-most portion of `A`.
+    2. If the validation method allows pruning domain labels when choosing the ADN, prune zero or more Domain Labels of `A` from left to right until encountering the Base Domain Name of `A` or the CA chooses to stop pruning, whichever comes first.
 
 When the ADN is an Onion Domain Name, the CA SHALL validate it in accordance with Appendix B.
 

--- a/docs/BR.md
+++ b/docs/BR.md
@@ -327,7 +327,7 @@ The Definitions found in the CA/Browser Forum's Network and Certificate System S
 
 **Authorized Ports**: One of the following ports: 80 (http), 443 (https), 25 (smtp), 22 (ssh).
 
-**Base Domain Name**: The portion of a given FQDN that is the first Domain Name node left of a registry-controlled or public suffix plus the registry-controlled or public suffix (e.g. "example.co.uk" or "example.com"). For FQDNs the right-most Domain Name node is a gTLD having ICANN Specification 13 in its registry agreement, the gTLD itself may be used as the Base Domain Name.
+**Base Domain Name**: The portion of a given FQDN that is the first Domain Name node left of a registry-controlled or public suffix plus the registry-controlled or public suffix (e.g. "example.co.uk" or "example.com"). For FQDNs where the right-most Domain Name node is a gTLD having ICANN Specification 13 in its registry agreement, the gTLD itself may be used as the Base Domain Name.
 
 **CAA**: From RFC 8659 (<https://tools.ietf.org/html/rfc8659>): "The Certification Authority Authorization (CAA) DNS Resource Record allows a DNS domain name holder to specify one or more Certification Authorities (CAs) authorized to issue certificates for that domain name. CAA Resource Records allow a public CA to implement additional controls to reduce the risk of unintended certificate mis-issue."
 

--- a/docs/BR.md
+++ b/docs/BR.md
@@ -759,7 +759,7 @@ The CA MUST follow this process when choosing the Authorization Domain Name "ADN
   a. Remove "\*." from the left-most portion of `A`.
   b. If the validation method allows pruning domain labels when choosing the ADN, prune zero or more Domain Labels of `A` from left to right until encountering the Base Domain Name of `A` or the CA chooses to stop pruning, whichever comes first.
 
-When the FQDN or Wildcard Domain Name is an Onion Domain Name, the CA SHALL validate it in accordance with Appendix B.
+When the ADN is an Onion Domain Name, the CA SHALL validate it in accordance with Appendix B.
 
 Completed validations of Applicant authority may be valid for the issuance of multiple Certificates over time. In all cases, the validation must have been initiated within the time period specified in the relevant requirement (such as [Section 4.2.1](#421-performing-identification-and-authentication-functions) of this document) prior to Certificate issuance. For purposes of domain validation, the term Applicant includes the Applicant's Parent Company, Subsidiary Company, or Affiliate.
 

--- a/docs/BR.md
+++ b/docs/BR.md
@@ -1038,7 +1038,7 @@ CAs performing validations using this method MUST implement Multi-Perspective Is
 
 ##### 3.2.2.4.22 DNS TXT Record with Persistent Value
 
-Confirming the Applicant's control over the ADN by verifying the presence of a Persistent DCV TXT Record identifying the Applicant. The record MUST be placed at the "`_validation-persist`" label prepended to the Authorization Domain Name being validated (i.e., "`_validation-persist.[Authorization Domain Name]`"). This prohibition overrides the Authorization Domain Name definition.
+Confirming the Applicant's control over the ADN by verifying the presence of a Persistent DCV TXT Record identifying the Applicant. The record MUST be placed at the "`_validation-persist`" label prepended to the Authorization Domain Name being validated (i.e., "`_validation-persist.[Authorization Domain Name]`").
 
 1. The RDATA value MUST conform to the `issue-value` syntax as defined in RFC 8659, Section 4.2; and
 2. The `issuer-domain-name` value MUST be an Issuer Domain Name disclosed by the CA in Section 4.2 of the CA's Certificate Policy and/or Certification Practices Statement; and

--- a/docs/BR.md
+++ b/docs/BR.md
@@ -752,12 +752,12 @@ The CA MUST follow this process when choosing the Authorization Domain Name "ADN
 
 1. Initialize `A` to the applied-for FQDN or Wildcard Domain Name.
 2. Choose a validation method. If `A` is a Wildcard Domain Name, the CA MUST choose a validation method that allows wildcard issuance. If `A` is an Onion Domain Name, the CA MUST choose a validation method that allows Onion Domain Name issuance.
-3. If `A` is an FQDN, choose at most one:
-    1. If the validation method allows CNAME lookups when choosing the ADN, replace `A` with the result of a DNS CNAME lookup of `A`.
-    2. If the validation method allows pruning domain labels when choosing the ADN, prune zero or more Domain Labels of `A` from left to right until encountering the Base Domain Name of `A` or the CA chooses to stop pruning, whichever comes first.
+3. If `A` is an FQDN:
+    1. Optionally, if the validation method allows CNAME lookups when choosing the ADN, replace `A` with the result of a DNS CNAME lookup of `A`.
+    2. If the validation method allows pruning domain labels when choosing the ADN, prune zero or more Domain Labels of `A` from left to right until `A` is equal to the Base Domain Name of `A`, or the CA chooses to stop pruning, whichever comes first.
 4. If `A` is a Wildcard Domain Name:
     1. Remove "\*." from the left-most portion of `A`.
-    2. If the validation method allows pruning domain labels when choosing the ADN, prune zero or more Domain Labels of `A` from left to right until encountering the Base Domain Name of `A` or the CA chooses to stop pruning, whichever comes first.
+    2. If the validation method allows pruning domain labels when choosing the ADN, prune zero or more Domain Labels of `A` from left to right until `A` is equal to the Base Domain Name of `A`, or the CA chooses to stop pruning, whichever comes first.
 
 When the ADN is an Onion Domain Name, the CA SHALL validate it in accordance with Appendix B.
 

--- a/docs/BR.md
+++ b/docs/BR.md
@@ -876,7 +876,7 @@ This method does not allow CNAME lookups when choosing the ADN.
 
 Effective January 15, 2025:
 - When issuing Subscriber Certificates, the CA MUST NOT rely on Domain Contact information obtained using an HTTPS website, regardless of whether previously obtained information is within the allowed reuse period.
-- When obtaining Domain Contact information for a requested ADN the CA:
+- When obtaining Domain Contact information for the ADN the CA:
      - if using the WHOIS protocol (RFC 3912), MUST query IANA's WHOIS server and follow referrals to the appropriate WHOIS server.
      - if using the Registry Data Access Protocol (RFC 7482), MUST utilize IANA's bootstrap file to identify and query the correct RDAP server for the domain.
      - MUST NOT rely on cached 1) WHOIS server information that is more than 48 hours old, or 2) RDAP bootstrap data from IANA that is more than 48 hours old, to ensure that it relies upon up-to-date and accurate information.
@@ -885,7 +885,7 @@ Effective January 15, 2025:
 
 Confirming the Applicant's control over the ADN by sending a Random Value via email and then receiving a confirming response utilizing the Random Value. The Random Value MUST be sent to a DNS CAA Email Contact. The relevant CAA Resource Record Set MUST be found using the search algorithm defined in RFC 8659, Section 3.
 
-The same email MAY be sent to multiple recipients as long as all recipients are DNS CAA Email Contacts for the Authorization Domain Name being validated.
+Each email MAY confirm control of multiple ADNs, provided that each email address is a DNS CAA Email Contact for each ADN being validated. The same email MAY be sent to multiple recipients, provided that each email address is a DNS CAA Email Contact for each ADN being validated.
 
 The Random Value SHALL be unique in each email. The email MAY be re-sent in its entirety, including the re-use of the Random Value, provided that its entire contents and recipient(s) SHALL remain unchanged. The Random Value SHALL remain valid for use in a confirming response for no more than 30 days from its creation. The CPS MAY specify a shorter validity period for Random Values.
 

--- a/docs/BR.md
+++ b/docs/BR.md
@@ -774,7 +774,8 @@ Effective March 15th, 2026: CAs MUST NOT use local policy to disable DNSSEC vali
 DNSSEC validation back to the IANA DNSSEC root trust anchor MAY be performed on all DNS queries associated with the validation of domain authorization or control by Remote Network Perspectives used for Multi-Perspective Issuance Corroboration.
 
 DNSSEC validation back to the IANA DNSSEC root trust anchor is considered outside the scope of self-audits performed to fulfill the requirements in [Section 8.7](#87-self-audits).
-CAs SHALL maintain a record of which domain validation method, including relevant BR version number, they used to validate every ADN.
+
+CAs SHALL maintain a record of which domain validation method, including relevant BR version number, they used to validate each ADN. CAs SHALL maintain a record of which ADN was used for validation of each FQDN or Wildcard Domain Name.
 
 **Note**: FQDNs may be listed in Subscriber Certificates using `dNSName`s in the `subjectAltName` extension or in Subordinate CA Certificates via `dNSName`s in `permittedSubtrees` within the Name Constraints extension.
 

--- a/docs/BR.md
+++ b/docs/BR.md
@@ -750,13 +750,18 @@ This section defines the permitted processes and procedures for validating the A
 
 The CA MUST follow this process when choosing the Authorization Domain Name "ADN" for validation of each applied-for FQDN or Wildcard Domain Name:
 
-1. Choose a validation method. If the applied-for FQDN or Wildcard Domain Name is a Wildcard Domain Name, the CA MUST choose a validation method that allows wildcard issuance. If the applied-for FQDN or Wildcard Domain Name is an Onion Domain Name, the CA MUST choose a validation method that allows Onion Domain Name issuance.
-2. Initialize `A` to the applied-for FQDN or Wildcard Domain Name.
-3. Remove "\*." from the left-most portion of `A`, if present.
-4. Optionally, if the validation method allows CNAME lookups when choosing the ADN, replace `A` with the result of a DNS CNAME lookup of `A`.
-5. Initialize `B` to the Base Domain Name of `A`.
-6. Optionally, if the validation method allows pruning domain labels when choosing the ADN, prune `N` Domain Labels from `A`, from left to right. The CA MUST choose a positive value of N such that `B` is either a suffix of or equal to the resulting `A`.
-7. Use `A` as the ADN for this validation.
+1. Initialize `A` to the applied-for FQDN or Wildcard Domain Name.
+2. Choose a validation method. If `A` is a Wildcard Domain Name, the CA MUST choose a validation method that allows wildcard issuance. If `A` is an Onion Domain Name, the CA MUST choose a validation method that allows Onion Domain Name issuance.
+3. If `A` is an FQDN:
+  a. Optionally, if the validation method allows CNAME lookups when choosing the ADN, replace `A` with the result of a DNS CNAME lookup of `A`.
+  b. Initialize `B` to the Base Domain Name of `A`.
+  c. Optionally, if the validation method allows pruning domain labels when choosing the ADN, prune `N` Domain Labels from `A`, from left to right. The CA MUST choose a positive value of N such that `B` is either a suffix of or equal to the resulting `A`.
+  d. Use `A` as the ADN for this validation.
+4. If `A` is a Wildcard Domain Name:
+  a. Remove "\*." from the left-most portion of `A`.
+  b. Initialize `B` to the Base Domain Name of `A`.
+  c. Optionally, if the validation method allows pruning domain labels when choosing the ADN, prune `N` Domain Labels from `A`, from left to right. The CA MUST choose a positive value of N such that `B` is either a suffix of or equal to the resulting `A`.
+  d. Use `A` as the ADN for this validation.
 
 When the FQDN or Wildcard Domain Name is an Onion Domain Name, the CA SHALL validate it in accordance with Appendix B.
 

--- a/docs/BR.md
+++ b/docs/BR.md
@@ -752,16 +752,12 @@ The CA MUST follow this process when choosing the Authorization Domain Name "ADN
 
 1. Initialize `A` to the applied-for FQDN or Wildcard Domain Name.
 2. Choose a validation method. If `A` is a Wildcard Domain Name, the CA MUST choose a validation method that allows wildcard issuance. If `A` is an Onion Domain Name, the CA MUST choose a validation method that allows Onion Domain Name issuance.
-3. If `A` is an FQDN:
-  a. Optionally, if the validation method allows CNAME lookups when choosing the ADN, replace `A` with the result of a DNS CNAME lookup of `A`.
-  b. Initialize `B` to the Base Domain Name of `A`.
-  c. Optionally, if the validation method allows pruning domain labels when choosing the ADN, prune `N` Domain Labels from `A`, from left to right. The CA MUST choose a positive value of N such that `B` is either a suffix of or equal to the resulting `A`.
-  d. Use `A` as the ADN for this validation.
+3. If `A` is an FQDN, choose at most one:
+  a. If the validation method allows CNAME lookups when choosing the ADN, replace `A` with the result of a DNS CNAME lookup of `A`.
+  c. If the validation method allows pruning domain labels when choosing the ADN, prune zero or more Domain Labels of `A` from left to right until encountering the Base Domain Name of `A` or the CA chooses to stop pruning, whichever comes first.
 4. If `A` is a Wildcard Domain Name:
   a. Remove "\*." from the left-most portion of `A`.
-  b. Initialize `B` to the Base Domain Name of `A`.
-  c. Optionally, if the validation method allows pruning domain labels when choosing the ADN, prune `N` Domain Labels from `A`, from left to right. The CA MUST choose a positive value of N such that `B` is either a suffix of or equal to the resulting `A`.
-  d. Use `A` as the ADN for this validation.
+  b. If the validation method allows pruning domain labels when choosing the ADN, prune zero or more Domain Labels of `A` from left to right until encountering the Base Domain Name of `A` or the CA chooses to stop pruning, whichever comes first.
 
 When the FQDN or Wildcard Domain Name is an Onion Domain Name, the CA SHALL validate it in accordance with Appendix B.
 

--- a/docs/BR.md
+++ b/docs/BR.md
@@ -753,11 +753,11 @@ The CA MUST follow this process when choosing the Authorization Domain Name "ADN
 1. Initialize `A` to the applied-for FQDN or Wildcard Domain Name.
 2. Choose a validation method. If `A` is a Wildcard Domain Name, the CA MUST choose a validation method that allows wildcard issuance. If `A` is an Onion Domain Name, the CA MUST choose a validation method that allows Onion Domain Name issuance.
 3. If `A` is an FQDN, choose at most one:
-  a. If the validation method allows CNAME lookups when choosing the ADN, replace `A` with the result of a DNS CNAME lookup of `A`.
-  b. If the validation method allows pruning domain labels when choosing the ADN, prune zero or more Domain Labels of `A` from left to right until encountering the Base Domain Name of `A` or the CA chooses to stop pruning, whichever comes first.
+    a. If the validation method allows CNAME lookups when choosing the ADN, replace `A` with the result of a DNS CNAME lookup of `A`.
+    b. If the validation method allows pruning domain labels when choosing the ADN, prune zero or more Domain Labels of `A` from left to right until encountering the Base Domain Name of `A` or the CA chooses to stop pruning, whichever comes first.
 4. If `A` is a Wildcard Domain Name:
-  a. Remove "\*." from the left-most portion of `A`.
-  b. If the validation method allows pruning domain labels when choosing the ADN, prune zero or more Domain Labels of `A` from left to right until encountering the Base Domain Name of `A` or the CA chooses to stop pruning, whichever comes first.
+    a. Remove "\*." from the left-most portion of `A`.
+    b. If the validation method allows pruning domain labels when choosing the ADN, prune zero or more Domain Labels of `A` from left to right until encountering the Base Domain Name of `A` or the CA chooses to stop pruning, whichever comes first.
 
 When the ADN is an Onion Domain Name, the CA SHALL validate it in accordance with Appendix B.
 

--- a/docs/BR.md
+++ b/docs/BR.md
@@ -730,7 +730,7 @@ The CA SHOULD implement a process to screen proxy servers in order to prevent re
 
 #### 3.2.2.4 Validation of Domain Authorization or Control
 
-Prior to 2026-09-15, the CA SHALL adhere to Section 3.2.2.4 (and its subsections) of these requirements or Section 3.2.2.4 of Version 2.2.7 of the Baseline Requirements for the Issuance and Management of Publicly-Trusted TLS Server Certificates. Effective 2026-09-15, the CA SHALL adhere to Section 3.2.2.4 of these requirements.
+Prior to 2026-09-15, the CA SHALL adhere to Section 3.2.2.4 (and its subsections) of these Requirements or Section 3.2.2.4 of Version 2.2.7 of the Baseline Requirements for the Issuance and Management of Publicly-Trusted TLS Server Certificates. Effective 2026-09-15, the CA SHALL adhere to Section 3.2.2.4 of these Requirements.
 
 This section defines the permitted processes and procedures for validating the Applicant's ownership or control of the domain.
 
@@ -750,7 +750,6 @@ The CA MUST follow this process when choosing the Authorization Domain Name (ADN
 | --------                                                   | - | - | - | - |
 | 3.2.2.4.4 Constructed Email to Domain Contact              | ✔ | ✔ | ✔ | - |
 | 3.2.2.4.7 DNS Change                                       | ✔ | ✔ | ✔ | - |
-| 3.2.2.4.8 IP Address                                       | - | - | - | - |
 | 3.2.2.4.12 Validating Applicant as a Domain Contact        | ✔ | ✔ | - | - |
 | 3.2.2.4.13 Email to DNS CAA Contact                        | ✔ | ✔ | ✔ | - |
 | 3.2.2.4.14 Email to DNS TXT Contact                        | ✔ | ✔ | ✔ | - |
@@ -767,14 +766,12 @@ When the ADN is an Onion Domain Name, the CA SHALL validate it in accordance wit
 
 Completed validations of Applicant authority may be valid for the issuance of multiple Certificates over time. In all cases, the validation must have been initiated within the time period specified in the relevant requirement (such as [Section 4.2.1](#421-performing-identification-and-authentication-functions) of this document) prior to Certificate issuance. For purposes of domain validation, the term Applicant includes the Applicant's Parent Company, Subsidiary Company, or Affiliate.
 
-Effective 2026-03-15: DNSSEC validation back to the IANA DNSSEC root trust anchor MUST be performed on all DNS queries associated with the validation of domain authorization or control by the Primary Network Perspective, including CNAME lookups performed while choosing the ADN. The DNS resolver used for all DNS queries associated with the validation of domain authorization or control by the Primary Network Perspective MUST:
+DNSSEC validation back to the IANA DNSSEC root trust anchor MUST be performed on all DNS queries associated with the validation of domain authorization or control by the Primary Network Perspective, including CNAME lookups performed while choosing the ADN. The DNS resolver used for all DNS queries associated with the validation of domain authorization or control by the Primary Network Perspective MUST:
 
 - perform DNSSEC validation using the algorithm defined in [RFC 4035, Section 5](https://datatracker.ietf.org/doc/html/rfc4035#section-5); and
 - support NSEC3 as defined in [RFC 5155](https://datatracker.ietf.org/doc/html/rfc5155); and
 - support SHA-2 as defined in [RFC 4509](https://datatracker.ietf.org/doc/html/rfc4509) and [RFC 5702](https://datatracker.ietf.org/doc/html/rfc5702); and
 - properly handle the security concerns enumerated in [RFC 6840, Section 4](https://datatracker.ietf.org/doc/html/rfc6840#section-4).
-
-Effective 2026-03-15: 
 
 For e-mail Domain Validation methods described in sections 3.2.2.4.4, 3.2.2.4.13, 3.2.2.4.14, DNSSEC validation back to the IANA DNSSEC root trust anchor MUST be performed on all DNS CNAME, CAA, TXT queries attempting to obtain the Authorization Domain Name associated with the validation of domain authorization or control by the Primary Network Perspective and CAs MUST NOT use local policy to disable DNSSEC validation. For all other DNS queries, DNSSEC validation back to the IANA DNSSEC root trust anchor SHOULD be performed and CAs SHOULD NOT use local policy to disable DNSSEC validation.
 
@@ -832,7 +829,7 @@ This method has been retired and MUST NOT be used. Prior validations using this 
 
 Confirming the Applicant's control over the ADN by confirming the presence of a Random Value or Request Token in a DNS CNAME, TXT or CAA record returned in a query for either:
 
-1. the Authorization Domain Name; or 
+1. the Authorization Domain Name; or
 2. the Authorization Domain Name prefixed with a Domain Label that begins with an underscore character.
 
 If a Random Value is used, the CA SHALL provide a Random Value unique to the Certificate request and SHALL not use the Random Value after:
@@ -846,13 +843,7 @@ If the CA or an Affiliate of the CA operates a DNS zone to which Applicants can 
 
 ##### 3.2.2.4.8 IP Address
 
-Confirming the Applicant's control over the ADN by confirming that the Applicant controls an IP address returned from a DNS lookup for A or AAAA records for the ADN in accordance with [Section 3.2.2.5](#3225-authentication-for-an-ip-address).
-
-CAs performing validations using this method MUST implement Multi-Perspective Issuance Corroboration as specified in [Section 3.2.2.9](#3229-multi-perspective-issuance-corroboration). To count as corroborating, a Network Perspective MUST observe the same IP address as the Primary Network Perspective.
-
-Effective March 15, 2026:
-- The CA MUST NOT rely on this method.
-- Prior validations using this method and validation data gathered according to this method MUST NOT be used to issue Subscriber Certificates.
+This method has been retired and MUST NOT be used. Prior validations using this method and validation data gathered according to this method SHALL NOT be used to issue certificates.
 
 ##### 3.2.2.4.9 Test Certificate
 
@@ -899,11 +890,17 @@ Effective March 15, 2028:
 
 Confirming the Applicant's control over the ADN by sending a Random Value via email and then receiving a confirming response utilizing the Random Value. The Random Value MUST be sent to a DNS TXT Record Email Contact for the Authorization Domain Name.
 
-The same email MAY be sent to multiple recipients as long as all recipients are DNS TXT Record Email Contacts for the Authorization Domain Name being validated.
+Each email MAY confirm control of multiple ADNs, provided that each email address is a DNS TXT Record Email Contact for each ADN being validated. The same email MAY be sent to multiple recipients, provided that each email address is a DNS TXT Record Email Contact for each ADN being validated.
 
 The Random Value SHALL be unique in each email. The email MAY be re-sent in its entirety, including the re-use of the Random Value, provided that its entire contents and recipient(s) SHALL remain unchanged. The Random Value SHALL remain valid for use in a confirming response for no more than 30 days from its creation. The CPS MAY specify a shorter validity period for Random Values.
 
 CAs performing validations using this method MUST implement Multi-Perspective Issuance Corroboration as specified in [Section 3.2.2.9](#3229-multi-perspective-issuance-corroboration). To count as corroborating, a Network Perspective MUST observe the same selected contact address used for domain validation as the Primary Network Perspective.
+
+Effective March 15, 2026, this method SHOULD NOT be used to issue Subscriber Certificates.
+
+Effective March 15, 2028:
+- The CA MUST NOT rely on this method.
+- Prior validations using this method and validation data gathered according to this method MUST NOT be used to issue Subscriber Certificates.
 
 ##### 3.2.2.4.15 Phone Contact with Domain Contact
 

--- a/docs/BR.md
+++ b/docs/BR.md
@@ -187,6 +187,7 @@ The following Certificate Policy identifiers are reserved for use by CAs to asse
 | 2026-03-15 | [6.3.2](#632-certificate-operational-periods-and-key-pair-usage-periods) | Maximum validity period of Subscriber Certificates is 200 days. |
 | 2026-03-15 | [7.1.2.4](#7124-technically-constrained-precertificate-signing-ca-certificate-profile) | CAs MUST NOT use Precertificate Signing CAs to issue Precertificates. CAs MUST NOT issue certificates using the Technically Constrained Precertificate Signing CA Certificate Profile specified in Section 7.1.2.4. |
 | 2026-09-15 | [7.1.3.2.1](#71321-rsa) | Sunset all remaining use of SHA-1 in Certificates and CRLs. |
+| 2026-09-15 | [3.2.2.4](#3224-validation-of-domain-authorization-or-control) | Authorization Domain Names must be derived based on the validation method to be used. |
 | 2027-03-15 | [3.2.2.4](#3224-validation-of-domain-authorization-or-control) and [3.2.2.5](#3225-authentication-for-an-ip-address) | CAs MUST NOT rely on Methods 3.2.2.4.16, 3.2.2.4.17, 3.2.2.5.2, and 3.2.2.5.5 to issue Subscriber Certificates. |
 | 2027-03-15 | [3.2.2.5.3](#32253-reverse-address-lookup) | CAs MUST NOT rely on Method 3.2.2.5.3 to issue Subscriber Certificates. |
 | 2027-03-15 | [4.2.1](#421-performing-identification-and-authentication-functions) | Domain Name and IP Address validation maximum data reuse period is 100 days. |
@@ -728,6 +729,8 @@ If the `subject:countryName` field is present, then the CA SHALL verify the coun
 The CA SHOULD implement a process to screen proxy servers in order to prevent reliance upon IP addresses assigned in countries other than where the Applicant is actually located.
 
 #### 3.2.2.4 Validation of Domain Authorization or Control
+
+Prior to 2026-09-15, the CA SHALL adhere to Section 3.2.2.4 (and its subsections) of these requirements or Section 3.2.2.4 of Version 2.2.7 of the Baseline Requirements for the Issuance and Management of Publicly-Trusted TLS Server Certificates. Effective 2026-09-15, the CA SHALL adhere to Section 3.2.2.4 of these requirements.
 
 This section defines the permitted processes and procedures for validating the Applicant's ownership or control of the domain.
 

--- a/docs/BR.md
+++ b/docs/BR.md
@@ -731,7 +731,7 @@ The CA SHOULD implement a process to screen proxy servers in order to prevent re
 
 This section defines the permitted processes and procedures for validating the Applicant's ownership or control of the domain.
 
-The CA MUST follow this process when choosing the Authorization Domain Name "ADN" for validation of each applied-for FQDN or Wildcard Domain Name:
+The CA MUST follow this process when choosing the Authorization Domain Name (ADN) for validation of each applied-for FQDN or Wildcard Domain Name:
 
 1. Initialize `A` to the applied-for FQDN or Wildcard Domain Name.
 2. Choose a validation method. If `A` is a Wildcard Domain Name, the CA MUST choose a validation method with a check in the Wildcard column below. If `A` is an Onion Domain Name, the CA MUST choose a validation method with a check in the Onion column below.
@@ -743,22 +743,22 @@ The CA MUST follow this process when choosing the Authorization Domain Name "ADN
     2. If the validation method has a check in the Prune column below, prune zero or more Domain Labels of `A` from left to right until `A` is equal to the Base Domain Name of `A`, or the CA chooses to stop pruning, whichever comes first.
 5. Use `A` as the ADN.
 
-| Method                                         | Wildcard | Prune | CNAME | Onion |
-| --------                                                    | - | - | - | - |
-| 3.2.2.4.4 Constructed Email to Domain Contact               | ✔️ | ✔️ | ✔️ | - |
-| 3.2.2.4.7 DNS Change                                        | ✔️ | ✔️ | ✔️ | - |
-| 3.2.2.4.8 IP Address                                        | - | - | - | - |
-| 3.2.2.4.12 Validating Applicant as a Domain Contact         | ✔️ | ✔️ | - | - |
-| 3.2.2.4.13 Email to DNS CAA Contact                         | ✔️ | ✔️ | ✔️ | - |
-| 3.2.2.4.14 Email to DNS TXT Contact                         | ✔️ | ✔️ | ✔️ | - |
-| 3.2.2.4.16 Phone Contact with DNS TXT Record Phone Contact  | ✔️ | ✔️ | ✔️ | - |
-| 3.2.2.4.17 Phone Contact with DNS CAA Phone Contact         | ✔️ | ✔️ | ✔️ | - |
-| 3.2.2.4.18 Agreed-Upon Change to Website v2                 | - | - | - | ✔️ |
-| 3.2.2.4.19 Agreed-Upon Change to Website - ACME             | - | - | - | ✔️ |
-| 3.2.2.4.20 TLS Using ALPN                                   | - | - | - | ✔️ |
-| 3.2.2.4.21 DNS Labeled with Account ID - ACME               | ✔️ | ✔️ | - | - |
-| 3.2.2.4.22 DNS TXT Record with Persistent Value             | ✔️ | ✔️ | - | - |
-| Appendix B.2.b                                              | ✔️ | ✔️ | - | ✔️ |
+| Method | Wildcard | Prune | CNAME | Onion |
+| --------                                                   | - | - | - | - |
+| 3.2.2.4.4 Constructed Email to Domain Contact              | ✔ | ✔ | ✔ | - |
+| 3.2.2.4.7 DNS Change                                       | ✔ | ✔ | ✔ | - |
+| 3.2.2.4.8 IP Address                                       | - | - | - | - |
+| 3.2.2.4.12 Validating Applicant as a Domain Contact        | ✔ | ✔ | - | - |
+| 3.2.2.4.13 Email to DNS CAA Contact                        | ✔ | ✔ | ✔ | - |
+| 3.2.2.4.14 Email to DNS TXT Contact                        | ✔ | ✔ | ✔ | - |
+| 3.2.2.4.16 Phone Contact with DNS TXT Record Phone Contact | ✔ | ✔ | ✔ | - |
+| 3.2.2.4.17 Phone Contact with DNS CAA Phone Contact        | ✔ | ✔ | ✔ | - |
+| 3.2.2.4.18 Agreed-Upon Change to Website v2                | - | - | - | ✔ |
+| 3.2.2.4.19 Agreed-Upon Change to Website - ACME            | - | - | - | ✔ |
+| 3.2.2.4.20 TLS Using ALPN                                  | - | - | - | ✔ |
+| 3.2.2.4.21 DNS Labeled with Account ID - ACME              | ✔ | ✔ | - | - |
+| 3.2.2.4.22 DNS TXT Record with Persistent Value            | ✔ | ✔ | - | - |
+| Appendix B.2.b                                             | ✔ | ✔ | - | ✔ |
 
 When the ADN is an Onion Domain Name, the CA SHALL validate it in accordance with Appendix B.
 
@@ -1003,7 +1003,7 @@ CAs performing validations using this method MUST implement Multi-Perspective Is
 
 ##### 3.2.2.4.22 DNS TXT Record with Persistent Value
 
-Confirming the Applicant's control over the ADN by verifying the presence of a Persistent DCV TXT Record identifying the Applicant. The record MUST be placed at the "`_validation-persist`" label prepended to the Authorization Domain Name being validated (i.e., "`_validation-persist.[Authorization Domain Name]`"). 
+Confirming the Applicant's control over the ADN by verifying the presence of a Persistent DCV TXT Record identifying the Applicant. The record MUST be placed at the "`_validation-persist`" label prepended to the Authorization Domain Name being validated (i.e., "`_validation-persist.[Authorization Domain Name]`").
 
 The CA MUST confirm the Persistent DCV TXT Record's RDATA value fulfills the following requirements:
 

--- a/docs/BR.md
+++ b/docs/BR.md
@@ -189,7 +189,7 @@ The following Certificate Policy identifiers are reserved for use by CAs to asse
 | 2026-03-15 | [7.1.2.4](#7124-technically-constrained-precertificate-signing-ca-certificate-profile) | CAs MUST NOT use Precertificate Signing CAs to issue Precertificates. CAs MUST NOT issue certificates using the Technically Constrained Precertificate Signing CA Certificate Profile specified in Section 7.1.2.4. |
 | 2026-07-15  | [5.4.1](#541-types-of-events-recorded) | Audit logs of verification activity MUST include specific information. |
 | 2026-09-15 | [7.1.3.2.1](#71321-rsa) | Sunset all remaining use of SHA-1 in Certificates and CRLs. |
-| 2026-09-15 | [3.2.2.4](#3224-validation-of-domain-authorization-or-control) | Authorization Domain Names must be derived based on the validation method to be used. |
+| 2026-11-15 | [3.2.2.4](#3224-validation-of-domain-authorization-or-control) | Authorization Domain Names must be derived based on the validation method to be used. |
 | 2027-03-15 | [3.2.2.4](#3224-validation-of-domain-authorization-or-control) and [3.2.2.5](#3225-authentication-for-an-ip-address) | CAs MUST NOT rely on Methods 3.2.2.4.16, 3.2.2.4.17, 3.2.2.5.2, and 3.2.2.5.5 to issue Subscriber Certificates. |
 | 2027-03-15 | [3.2.2.5.3](#32253-reverse-address-lookup) | CAs MUST NOT rely on Method 3.2.2.5.3 to issue Subscriber Certificates. |
 | 2027-03-15 | [4.2.1](#421-performing-identification-and-authentication-functions) | Domain Name and IP Address validation maximum data reuse period is 100 days. |

--- a/docs/BR.md
+++ b/docs/BR.md
@@ -1073,7 +1073,7 @@ Effective March 15, 2027:
 
 ##### 3.2.2.5.3 Reverse Address Lookup
 
-Confirming the Applicant's control over the IP Address by obtaining an FQDN associated with the IP Address through a reverse-IP lookup on the IP Address and then using that FQDN as an ADN and performing validation using a method permitted under [Section 3.2.2.4](#3224-validation-of-domain-authorization-or-control). The ADN for this method MUST be exactly the FQDN returned from the reverse-IP lookup. The ADN selection algorithm in section 3.2.2.4 does not apply.
+Confirming the Applicant's control over the IP Address by obtaining an FQDN associated with the IP Address through a reverse-IP lookup on the IP Address and then using that FQDN as an ADN and performing validation using a method permitted under [Section 3.2.2.4](#3224-validation-of-domain-authorization-or-control). Effective 2026-11-15, the ADN for this method MUST be exactly the FQDN returned from the reverse-IP lookup; the ADN selection algorithm in section 3.2.2.4 does not apply.
 
 CAs performing validations using this method MUST implement Multi-Perspective Issuance Corroboration as specified in [Section 3.2.2.9](#3229-multi-perspective-issuance-corroboration). To count as corroborating, a Network Perspective MUST observe the same FQDN as the Primary Network Perspective.
 

--- a/docs/BR.md
+++ b/docs/BR.md
@@ -801,7 +801,7 @@ This method has been retired and MUST NOT be used. Prior validations using this 
 
 Confirm the Applicant's control over the ADN by:
 
-1. Sending an email to one or more addresses created by using 'admin', 'administrator', 'webmaster', 'hostmaster', or 'postmaster' as the local part, followed by the at-sign ("@"), followed by the Authorization Domain Name; and
+1. Sending an email to one or more addresses created by using 'admin', 'administrator', 'webmaster', 'hostmaster', or 'postmaster' as the local part, followed by the at-sign ("@"), followed by the ADN; and
 2. including a Random Value in the email; and
 3. receiving a confirming response utilizing the Random Value.
 
@@ -829,8 +829,8 @@ This method has been retired and MUST NOT be used. Prior validations using this 
 
 Confirming the Applicant's control over the ADN by confirming the presence of a Random Value or Request Token in a DNS CNAME, TXT or CAA record returned in a query for either:
 
-1. the Authorization Domain Name; or
-2. the Authorization Domain Name prefixed with a Domain Label that begins with an underscore character.
+1. the ADN; or
+2. the ADN prefixed with a Domain Label that begins with an underscore character.
 
 If a Random Value is used, the CA SHALL provide a Random Value unique to the Certificate request and SHALL not use the Random Value after:
 
@@ -888,7 +888,7 @@ Effective March 15, 2028:
 
 ##### 3.2.2.4.14 Email to DNS TXT Contact
 
-Confirming the Applicant's control over the ADN by sending a Random Value via email and then receiving a confirming response utilizing the Random Value. The Random Value MUST be sent to a DNS TXT Record Email Contact for the Authorization Domain Name.
+Confirming the Applicant's control over the ADN by sending a Random Value via email and then receiving a confirming response utilizing the Random Value. The Random Value MUST be sent to a DNS TXT Record Email Contact for the ADN.
 
 Each email MAY confirm control of multiple ADNs, provided that each email address is a DNS TXT Record Email Contact for each ADN being validated. The same email MAY be sent to multiple recipients, provided that each email address is a DNS TXT Record Email Contact for each ADN being validated.
 
@@ -951,7 +951,7 @@ Confirming the Applicant's control over the ADN by verifying that the Request To
 
 The file containing the Request Token or Random Value:
 
-1. MUST be located on the Authorization Domain Name, and
+1. MUST be located on the ADN, and
 2. MUST be located under the "/.well-known/pki-validation" directory, and
 3. MUST be retrieved via either the "http" or "https" scheme, and
 4. MUST be accessed over an Authorized Port.
@@ -1003,7 +1003,7 @@ CAs performing validations using this method MUST implement Multi-Perspective Is
 
 ##### 3.2.2.4.22 DNS TXT Record with Persistent Value
 
-Confirming the Applicant's control over the ADN by verifying the presence of a Persistent DCV TXT Record identifying the Applicant. The record MUST be placed at the "`_validation-persist`" label prepended to the Authorization Domain Name being validated (i.e., "`_validation-persist.[Authorization Domain Name]`").
+Confirming the Applicant's control over the ADN by verifying the presence of a Persistent DCV TXT Record identifying the Applicant. The record MUST be placed at the "`_validation-persist`" label prepended to the ADN being validated (i.e., "`_validation-persist.[Authorization Domain Name]`").
 
 The CA MUST confirm the Persistent DCV TXT Record's RDATA value fulfills the following requirements:
 
@@ -4031,17 +4031,17 @@ The DNS TXT record MUST be placed on the "`_validation-contactphone`" subdomain 
 
 This appendix defines permissible verification procedures for including one or more Onion Domain Names in a Certificate.
 
-1. The Authorization Domain Name MUST contain at least two Domain Labels, where the rightmost Domain Label is "onion", and the Domain Label immediately preceding the rightmost "onion" Domain Label is a valid Version 3 Onion Address, as defined in Section 6 of the Tor Rendezvous Specification - Version 3 located at <https://spec.torproject.org/rend-spec-v3>.
+1. The ADN MUST contain at least two Domain Labels, where the rightmost Domain Label is "onion", and the Domain Label immediately preceding the rightmost "onion" Domain Label is a valid Version 3 Onion Address, as defined in Section 6 of the Tor Rendezvous Specification - Version 3 located at <https://spec.torproject.org/rend-spec-v3>.
 
-2. The CA MUST verify the Applicant's control over the Authorization Domain Name using at least one of the methods listed below:
+2. The CA MUST verify the Applicant's control over the ADN using at least one of the methods listed below:
 
    a. The CA MAY verify the Applicant's control over the ADN by using any method from [Section 3.2.2.4](#3224-validation-of-domain-authorization-or-control) that says "This method allows Onion Domain Name issuance", with this modification:
 
-      When these methods are used to verify the Applicant's control over an Onion Domain Name, the CA MUST use Tor protocol to establish a connection to the Authorization Domain Name. The CA MUST NOT delegate or rely on a third-party to establish the connection, such as by using Tor2Web.
+      When these methods are used to verify the Applicant's control over an Onion Domain Name, the CA MUST use Tor protocol to establish a connection to the ADN. The CA MUST NOT delegate or rely on a third-party to establish the connection, such as by using Tor2Web.
 
       **Note**: This section does not override or supersede any provisions specified within the respective methods. The CA MUST only use a method if it is still permitted within that section.
 
-   b. The CA MAY verify the Applicant's control over the .onion service corresponding to the Authorization Domain Name by having the Applicant provide a Certificate Request signed using the .onion service's private key if the Attributes section of the certificationRequestInfo contains:
+   b. The CA MAY verify the Applicant's control over the .onion service corresponding to the ADN by having the Applicant provide a Certificate Request signed using the .onion service's private key if the Attributes section of the certificationRequestInfo contains:
 
       i. A caSigningNonce attribute that contains a Random Value that is generated by the CA; and
       ii. An applicantSigningNonce attribute that contains a single value. The CA MUST recommend to Applicants that the applicantSigningNonce value should contain at least 64 bits of entropy.

--- a/docs/BR.md
+++ b/docs/BR.md
@@ -1,11 +1,11 @@
 ---
 title: Baseline Requirements for the Issuance and Management of Publicly-Trusted TLS Server Certificates
 
-subtitle: Version 2.2.8
+subtitle: Version 2.2.9
 author:
   - CA/Browser Forum
 
-date: 16-Jun-2026
+date: 6-Aug-2026
 
 copyright: |
   Copyright 2026 CA/Browser Forum
@@ -163,6 +163,7 @@ The following Certificate Policy identifiers are reserved for use by CAs to asse
 | 2.2.6 | SC095 | Clean-up 2025                                                                           | 2026-02-27 | 2026-03-31 |
 | 2.2.7 | SC099 | Improve Recording of Validation Method                                                  | 2026-04-18 | 2026-05-19 |
 | 2.2.8 | SC098 | Process RFC 8657 CAA Parameters                                                         | 2026-05-13 | 2026-06-16 |
+| 2.2.9 | SC101 | Clarify Authorization Domain Names                                                      | 2026-07-02 | 2026-08-06 |
 
 \* Effective Date and Additionally Relevant Compliance Date(s)
 

--- a/docs/BR.md
+++ b/docs/BR.md
@@ -741,11 +741,11 @@ The CA MUST follow this process when choosing the Authorization Domain Name (ADN
 1. Initialize `A` to the applied-for FQDN or Wildcard Domain Name.
 2. Choose a validation method. If `A` is a Wildcard Domain Name, the CA MUST choose a validation method with a check in the Wildcard column below. If `A` is an Onion Domain Name, the CA MUST choose a validation method with a check in the Onion column below.
 3. If `A` is an FQDN:
-    1. Optionally, if the validation method has a check in the CNAME column below, replace `A` with the result of a DNS CNAME lookup of `A`. This step may be repeated.
-    2. If the validation method has a check in the Prune column below, prune zero or more Domain Labels of `A` from left to right until `A` is equal to the Base Domain Name of `A`, or the CA chooses to stop pruning, whichever comes first.
+    1. If the validation method has a check in the CNAME column below, the CA MAY replace `A` with the result of a DNS CNAME lookup of `A`. This step may be repeated.
+    2. If the validation method has a check in the Prune column below and `A` is not equal to the Base Domain Name of `A`, the CA MAY replace `A` with the result of pruning the leftmost Domain Label from `A`. This step may be repeated.
 4. If `A` is a Wildcard Domain Name:
     1. Remove "\*." from the left-most portion of `A`.
-    2. If the validation method has a check in the Prune column below, prune zero or more Domain Labels of `A` from left to right until `A` is equal to the Base Domain Name of `A`, or the CA chooses to stop pruning, whichever comes first.
+    2. If the validation method has a check in the Prune column below and `A` is not equal to the Base Domain Name of `A`, the CA MAY replace `A` with the result of pruning the leftmost Domain Label from `A`. This step may be repeated.
 5. Use `A` as the ADN.
 
 | Method | Wildcard | Prune | CNAME | Onion |

--- a/docs/BR.md
+++ b/docs/BR.md
@@ -732,7 +732,7 @@ The CA SHOULD implement a process to screen proxy servers in order to prevent re
 
 #### 3.2.2.4 Validation of Domain Authorization or Control
 
-Prior to 2026-09-15, the CA SHALL adhere to Section 3.2.2.4 (and its subsections) of these Requirements or Section 3.2.2.4 of Version 2.2.7 of the Baseline Requirements for the Issuance and Management of Publicly-Trusted TLS Server Certificates. Effective 2026-09-15, the CA SHALL adhere to Section 3.2.2.4 of these Requirements.
+Prior to 2026-11-15, the CA SHALL adhere to Section 3.2.2.4 (and its subsections) of these Requirements *or* Section 3.2.2.4 of Version 2.2.7 of the Baseline Requirements for the Issuance and Management of Publicly-Trusted TLS Server Certificates. Effective 2026-11-15, the CA SHALL adhere to Section 3.2.2.4 of these Requirements.
 
 This section defines the permitted processes and procedures for validating the Applicant's ownership or control of the domain.
 


### PR DESCRIPTION
Simplify the definition of ADN and move the algorithm in 3.2.2.4. Choosing an ADN is a precursor to doing validation. Every validation operates on an ADN.

Simplify the language in each method around pruning labels and wildcard issuance. Add corresponding language about following CNAMEs when choosing the ADN, and around onion issuance.

Require record keeping when choosing the ADN.

Replace retired methods with language saying they are retired.

Define Base Domain Name as a function of any given FQDN.

Move the definition of Domain Contact into the only remaining method that uses it (3.2.2.4.12 Validating Applicant as a Domain Contact). Note that this method does not allow CNAME lookups when choosing the ADN, because it previously relied on Base Domain Name, which previously had the language "applied-for FQDN".

Use "ADN" consistently in method definitions instead of "FQDN" (which is insufficiently precise as to whether it's the applied-for FQDN or the ADN).

Clean up the language in the onion section around ADNs.

Here's a table of the methods and what ADN operations can happen on them according to this PR (plus onion issuance):

| Method                                         | Wildcard | Prune | CNAME | Onion |
| --------                                                    | - | - | - | - |
| 3.2.2.4.4 Constructed Email to Domain Contact               | ✔️ | ✔️ | ✔️ | - |
| 3.2.2.4.7 DNS Change                                        | ✔️ | ✔️ | ✔️ | - |
| 3.2.2.4.8 IP Address                                        | - | - | - | - |
| 3.2.2.4.12 Validating Applicant as a Domain Contact         | ✔️ | ✔️ | - | - |
| 3.2.2.4.13 Email to DNS CAA Contact                         | ✔️ | ✔️ | ✔️ | - |
| 3.2.2.4.14 Email to DNS TXT Contact                         | ✔️ | ✔️ | ✔️ | - |
| 3.2.2.4.16 Phone Contact with DNS TXT Record Phone Contact  | ✔️ | ✔️ | ✔️ | - |
| 3.2.2.4.17 Phone Contact with DNS CAA Phone Contact         | ✔️ | ✔️ | ✔️ | - |
| 3.2.2.4.18 Agreed-Upon Change to Website v2                 | - | - | - | ✔️ |
| 3.2.2.4.19 Agreed-Upon Change to Website - ACME             | - | - | - | ✔️ |
| 3.2.2.4.20 TLS Using ALPN                                   | - | - | - | ✔️ |
| 3.2.2.4.21 DNS Labeled with Account ID - ACME               | ✔️ | ✔️ | - | - |
| 3.2.2.4.22 DNS TXT Record with Persistent Value             | ✔️ | ✔️ | - | - |
| Appendix B.2.b                                              | ✔️ | ✔️ | - | ✔️ |

This is a more in-depth replacement for #619.