### PR TITLE
Ballot SC-099: Improve Recording of Validation Methods

### DIFF
--- a/docs/BR.md
+++ b/docs/BR.md
@@ -230,6 +230,7 @@ The following Certificate Policy identifiers are reserved for use by CAs to asse
 | 2026-03-15     | 4.2.1                     | Domain Name and IP Address validation maximum data reuse period is 200 days.     |
 | 2026-03-15     | 6.3.2                     | Maximum validity period of Subscriber Certificates is 200 days.   |
 | 2026-03-15     | 7.1.2.4                   | CAs MUST NOT use Precertificate Signing CAs to issue Precertificates. CAs MUST NOT issue certificates using the Technically Constrained Precertificate Signing CA Certificate Profile specified in Section 7.1.2.4.    |
+| 2026-07-15     | 5.4.1                     | Audit logged validation records MUST include specific information.    |
 | 2026-09-15     | 7.1.3.2.1                 | Sunset all remaining use of SHA-1 in Certificates and CRLs.   |
 | 2027-03-15     | 3.2.2.4 and 3.2.2.5       | CAs MUST NOT rely on Methods 3.2.2.4.16, 3.2.2.4.17, 3.2.2.5.2, and 3.2.2.5.5 to issue Subscriber Certificates.    |
 | 2027-03-15     | 3.2.2.5.3                 | CAs MUST NOT rely on Method 3.2.2.5.3 to issue Subscriber Certificates.    |
@@ -1860,7 +1861,7 @@ The CA SHALL record at least the following events:
 
 2. Subscriber Certificate lifecycle management events, including:
    1. Certificate requests, renewal, and re-key requests, and revocation;
-   2. All verification activities stipulated in these Requirements and the CA's Certification Practice Statement, minimally recording the following information:
+   2. All verification activities stipulated in these Requirements and the CA's Certification Practice Statement. Effective 2026-07-15, records MUST include at a minimum:
       1. the information being validated (e.g., the applied-for FQDN or the organization name);
       2. the ADN used (if applicable and different from the applied-for FQDN); and
       3. the validation method used (e.g., the BRs section number or the registered label of an ACME validation method);

--- a/docs/BR.md
+++ b/docs/BR.md
@@ -1864,15 +1864,15 @@ The CA SHALL record at least the following events:
       1. the information being validated (e.g., the applied-for FQDN or the organization name);
       2. the ADN used (if applicable and different from the applied-for FQDN); and
       3. the validation method used (e.g., the BRs section number or the registered label of an ACME validation method);
-   4. Approval and rejection of certificate requests;
-   5. Issuance of Certificates; 
-   6. Generation of Certificate Revocation Lists; and 
-   7. Signing of OCSP Responses (as described in [Section 4.9](#49-certificate-revocation-and-suspension) and [Section 4.10](#410-certificate-status-services)).
-   8. Multi-Perspective Issuance Corroboration attempts from each Network Perspective, minimally recording the following information:
+   3. Approval and rejection of certificate requests;
+   4. Issuance of Certificates; 
+   5. Generation of Certificate Revocation Lists; and 
+   6. Signing of OCSP Responses (as described in [Section 4.9](#49-certificate-revocation-and-suspension) and [Section 4.10](#410-certificate-status-services)).
+   7. Multi-Perspective Issuance Corroboration attempts from each Network Perspective, minimally recording the following information:
       1. an identifier that uniquely identifies the Network Perspective used;
       2. the attempted domain name and/or IP address; and
       3. the result of the attempt (e.g., "domain validation pass/fail", "CAA permission/prohibition").
-   9. Multi-Perspective Issuance Corroboration quorum results for each attempted domain name or IP address represented in a Certificate request (i.e., "3/4" which should be interpreted as "Three (3) out of four (4) attempted Network Perspectives corroborated the determinations made by the Primary Network Perspective).
+   8. Multi-Perspective Issuance Corroboration quorum results for each attempted domain name or IP address represented in a Certificate request (i.e., "3/4" which should be interpreted as "Three (3) out of four (4) attempted Network Perspectives corroborated the determinations made by the Primary Network Perspective).
 
 3. Security events, including:
    1. Successful and unsuccessful PKI system access attempts;

--- a/docs/BR.md
+++ b/docs/BR.md
@@ -797,8 +797,6 @@ DNSSEC validation back to the IANA DNSSEC root trust anchor is considered outsid
 
 DNSSEC validation back to the IANA DNSSEC root trust anchor is considered outside the scope of the logging requirements of [Section 5.4.1](#541-types-of-events-recorded).
 
-CAs SHALL maintain a record of which domain validation method, including relevant BR version number, they used to validate every domain.
-
 **Note**: FQDNs may be listed in Subscriber Certificates using `dNSName`s in the `subjectAltName` extension or in Subordinate CA Certificates via `dNSName`s in `permittedSubtrees` within the Name Constraints extension.
 
 ##### 3.2.2.4.1 Validating the Applicant as a Domain Contact
@@ -1092,8 +1090,6 @@ This section defines the permitted processes and procedures for validating the A
 The CA SHALL confirm that prior to issuance, the CA has validated each IP Address listed in the Certificate using at least one of the methods specified in this section.
 
 Completed validations of Applicant authority may be valid for the issuance of multiple Certificates over time. In all cases, the validation must have been initiated within the time period specified in the relevant requirement (such as [Section 4.2.1](#421-performing-identification-and-authentication-functions) of this document) prior to Certificate issuance. For purposes of IP Address validation, the term Applicant includes the Applicant's Parent Company, Subsidiary Company, or Affiliate.
-
-After July 31, 2019, CAs SHALL maintain a record of which IP validation method, including the relevant BR version number, was used to validate every IP Address.
 
 ##### 3.2.2.5.1 Agreed-Upon Change to Website
 
@@ -1864,16 +1860,19 @@ The CA SHALL record at least the following events:
 
 2. Subscriber Certificate lifecycle management events, including:
    1. Certificate requests, renewal, and re-key requests, and revocation;
-   2. All verification activities stipulated in these Requirements and the CA's Certification Practice Statement;
-   3. Approval and rejection of certificate requests;
-   4. Issuance of Certificates; 
-   5. Generation of Certificate Revocation Lists; and 
-   6. Signing of OCSP Responses (as described in [Section 4.9](#49-certificate-revocation-and-suspension) and [Section 4.10](#410-certificate-status-services)).
-   7. Multi-Perspective Issuance Corroboration attempts from each Network Perspective, minimally recording the following information:
+   2. All verification activities stipulated in these Requirements and the CA's Certification Practice Statement, minimally recording the following information:
+      1. the information being validated (e.g., the applied-for FQDN or the organization name);
+      2. the ADN used (if applicable and different from the applied-for FQDN); and
+      3. the validation method used (e.g., the BRs section number or the registered label of an ACME validation method);
+   4. Approval and rejection of certificate requests;
+   5. Issuance of Certificates; 
+   6. Generation of Certificate Revocation Lists; and 
+   7. Signing of OCSP Responses (as described in [Section 4.9](#49-certificate-revocation-and-suspension) and [Section 4.10](#410-certificate-status-services)).
+   8. Multi-Perspective Issuance Corroboration attempts from each Network Perspective, minimally recording the following information:
       1. an identifier that uniquely identifies the Network Perspective used;
       2. the attempted domain name and/or IP address; and
       3. the result of the attempt (e.g., "domain validation pass/fail", "CAA permission/prohibition").
-   8. Multi-Perspective Issuance Corroboration quorum results for each attempted domain name or IP address represented in a Certificate request (i.e., "3/4" which should be interpreted as "Three (3) out of four (4) attempted Network Perspectives corroborated the determinations made by the Primary Network Perspective).
+   9. Multi-Perspective Issuance Corroboration quorum results for each attempted domain name or IP address represented in a Certificate request (i.e., "3/4" which should be interpreted as "Three (3) out of four (4) attempted Network Perspectives corroborated the determinations made by the Primary Network Perspective).
 
 3. Security events, including:
    1. Successful and unsuccessful PKI system access attempts;

--- a/docs/BR.md
+++ b/docs/BR.md
@@ -1,11 +1,11 @@
 ---
 title: Baseline Requirements for the Issuance and Management of Publicly-Trusted TLS Server Certificates
 
-subtitle: Version 2.2.6
+subtitle: Version 2.2.7
 author:
   - CA/Browser Forum
 
-date: 31-March-2026
+date: 19-May-2026
 
 copyright: |
   Copyright 2026 CA/Browser Forum
@@ -161,6 +161,7 @@ The following Certificate Policy identifiers are reserved for use by CAs to asse
 | 2.2.4 | SC096 | Carve-out for DNSSEC verification logging requirements                                  | 2026-01-14 | 2026-02-17 |
 | 2.2.5 | SC097 | Sunset all remaining use of SHA-1 signatures in Certificates and CRLs                   | 2026-02-24 | 2026-02-25 |
 | 2.2.6 | SC095 | Clean-up 2025                                                                           | 2026-02-27 | 2026-03-31 |
+| 2.2.7 | SC099 | Improve Recording of Validation Method                                                  | 2026-04-18 | 2026-05-19 |
 
 \* Effective Date and Additionally Relevant Compliance Date(s)
 


### PR DESCRIPTION
The current BRs contain the following text in Sections 3.2.2.4 and 3.2.2.5:

> CAs SHALL maintain a record of which [domain/IP] validation method, including relevant BR version number, they used to validate every [domain/IP Address].

This text is problematic for four reasons:
- it only applies to domains and IP addresses, not other things being validated like organization information;
- the requirement to "maintain a record" is unclear (in audit logs? in a database? in a document?);
- no one is sure what the "relevant BR version" is (the effective version when the validation happened? the version that the validation process believes it implements?); and
- the text is not in Section 5.4.1, which is where the BRs concentrate requirements about recording information.

To resolve these issues, we need to start from first principles. The goal, as evidenced by discussion when this requirement was introduced and recollections of CA/BF members who were participating at the time, is to ensure that CAs and auditors are able to definitively identify the validation process the with which the CA was required to comply for any given validation.

To determine what rules governed any given validation, we need two pieces of information:
1. When they performed that validation. The current requirements in Section 5.4.1 already require the CA to audit log the time of every verification procedure.
2. What validation method the CA used. This ballot augments Section 5.4.1 to also require that the CA audit log the validation method used, as well as other useful information.

Because we can accomplish the goal with a small addition to Section 5.4.1, this ballot removes the current text from Sections 3.2.2.4 and 3.2.2.5.

Note that this ballot removes the requirement to "record" the "relevant BR version number". This is not considered a loss, for several reasons:
- No CA or auditor should be relying on a logged BR version number to determine which version of the BRs governed the validation. The logged version number is not enforceable; the only information which can be relied upon to map a validation to a BRs version is the time at which the validation was performed.
- If a new version of the BRs adds requirements to a validation method, but gates those new requirements behind a future effective date, the logged version number may indicate that the CA complies with that new version long before the CA has actually implemented the soon-to-be-required behavior.
- If a new version of the BRs adds requirements to a validation method immediately upon the new version becoming effective, then a CA must update their processes to comply before the new version of the BRs is even published, and therefore the logged version number will be out-of-date compared to the implemented behavior.
- Part of the original motivation behind these statements was to encourage CAs to actually read new versions of the BRs and ensure their processes comply with them. We now have other mechanisms to encourage this behavior, such as CCADB self-assessments.

Therefore we conclude that recording the relevant BRs version number is neither useful nor well-specified, and therefore should not be included in the BRs.

This issue was discussed [on Mozilla dev-security-policy@](https://groups.google.com/a/mozilla.org/g/dev-security-policy/c/x4zRcboSDwU) as well as at the CA/BF Face-to-Face Meeting 67 in Houston on March 10, 2026. The conclusion of those discussions was that we should create this ballot.

This ballot is written by Aaron Gable (ISRG / Let's Encrypt) and endorsed by Gurleen Grewal (Google Trust Services), Trev Ponds-White (Amazon Trust Services), and Roman Fischer (SwissSign).