### PR TITLE
SC-XXX: Permit ML-DSA public keys and signatures in certificates

### DIFF
--- a/docs/BR.md
+++ b/docs/BR.md
@@ -3412,6 +3412,8 @@ The CA SHALL indicate an ML-DSA key using one of the following algorithm identif
 - ML-DSA-65 (OID: 2.16.840.1.101.3.4.3.18), or
 - ML-DSA-87 (OID: 2.16.840.1.101.3.4.3.19).
 
+As described in [Section 6.1.5](#615-key-sizes), ML-DSA CA Key Pairs MUST use the ML-DSA-87 parameter set.
+
 The parameters for ML-DSA keys SHALL be absent. The CA MUST NOT use HashML-DSA; only "pure" ML-DSA is permitted.
 
 When encoded, the AlgorithmIdentifier for ML-DSA keys SHALL be byte-for-byte identical with the following hex-encoded bytes:
@@ -3531,10 +3533,6 @@ If the signing key is P-521, the signature MUST use ECDSA with SHA-512. When enc
 ##### 7.1.3.2.3 ML-DSA
 
 The CA SHALL use the appropriate signature algorithm and encoding based upon the signing key used.
-
-If the signing key is ML-DSA-44, the signature algorithm SHALL be id-ml-dsa-44 (OID: 2.16.840.1.101.3.4.3.17). When encoded, the `AlgorithmIdentifier` SHALL be byte-for-byte identical with the following hex-encoded bytes: `300b0609608648016503040311`.
-
-If the signing key is ML-DSA-65, the signature algorithm SHALL be id-ml-dsa-65 (OID: 2.16.840.1.101.3.4.3.18). When encoded, the `AlgorithmIdentifier` SHALL be byte-for-byte identical with the following hex-encoded bytes: `300b0609608648016503040312`.
 
 If the signing key is ML-DSA-87, the signature algorithm SHALL be id-ml-dsa-87 (OID: 2.16.840.1.101.3.4.3.19). When encoded, the `AlgorithmIdentifier` SHALL be byte-for-byte identical with the following hex-encoded bytes: `300b0609608648016503040313`.
 

--- a/docs/BR.md
+++ b/docs/BR.md
@@ -161,7 +161,7 @@ The following Certificate Policy identifiers are reserved for use by CAs to asse
 | 2.2.4 | SC096 | Carve-out for DNSSEC verification logging requirements                                  | 2026-01-14 | 2026-02-17 |
 | 2.2.5 | SC097 | Sunset all remaining use of SHA-1 signatures in Certificates and CRLs                   | 2026-02-24 | 2026-02-25 |
 | 2.2.6 | SC095 | Clean-up 2025                                                                           | 2026-02-27 | 2026-03-31 |
-| 2.2.X | SCXXX | Permit ML-DSA public keys in Certificates                                               | 2026-XX-XX | 2026-XX-XX |
+| 2.2.X | SCXXX | Permit ML-DSA public keys and signatures in Certificates                                | 2026-XX-XX | 2026-XX-XX |
 
 \* Effective Date and Additionally Relevant Compliance Date(s)
 

--- a/docs/BR.md
+++ b/docs/BR.md
@@ -1,11 +1,11 @@
 ---
 title: Baseline Requirements for the Issuance and Management of Publicly-Trusted TLS Server Certificates
 
-subtitle: Version 2.2.6
+subtitle: Version 2.2.x
 author:
   - CA/Browser Forum
 
-date: 31-March-2026
+date: XX-XX-2026
 
 copyright: |
   Copyright 2026 CA/Browser Forum
@@ -161,6 +161,7 @@ The following Certificate Policy identifiers are reserved for use by CAs to asse
 | 2.2.4 | SC096 | Carve-out for DNSSEC verification logging requirements                                  | 2026-01-14 | 2026-02-17 |
 | 2.2.5 | SC097 | Sunset all remaining use of SHA-1 signatures in Certificates and CRLs                   | 2026-02-24 | 2026-02-25 |
 | 2.2.6 | SC095 | Clean-up 2025                                                                           | 2026-02-27 | 2026-03-31 |
+| 2.2.X | SCXXX | Permit ML-DSA-87 public keys in Certificates                                            | 2026-XX-XX | 2026-XX-XX |
 
 \* Effective Date and Additionally Relevant Compliance Date(s)
 
@@ -2061,6 +2062,10 @@ For ECDSA key pairs, the CA SHALL:
 
 - Ensure that the key represents a valid point on the NIST P-256, NIST P-384 or NIST P-521 elliptic curve.
 
+For ML-DSA key pairs, the CA SHALL:
+
+- Ensure that the key uses the ML-DSA-87 (OID: 2.16.840.1.101.3.4.3.19) parameter set.
+
 No other algorithms or key sizes are permitted.
 
 ### 6.1.6 Public key parameters generation and quality checking
@@ -2068,6 +2073,8 @@ No other algorithms or key sizes are permitted.
 RSA: The CA SHALL confirm that the value of the public exponent is an odd number equal to 3 or more. Additionally, the public exponent SHOULD be in the range between 2^16 + 1 and 2^256 - 1. The modulus SHOULD also have the following characteristics: an odd number, not the power of a prime, and have no factors smaller than 752. [Source: Section 5.3.3, NIST SP 800-89]
 
 ECDSA: The CA SHOULD confirm the validity of all keys using either the ECC Full Public Key Validation Routine or the ECC Partial Public Key Validation Routine. [Source: Sections 5.6.2.3.2 and 5.6.2.3.3, respectively, of NIST SP 800-56A: Revision 2]
+
+ML-DSA: No stipulation.
 
 ### 6.1.7 Key usage purposes (as per X.509 v3 key usage field)
 
@@ -2867,7 +2874,7 @@ Table: Permitted `policyQualifiers`
 
 ##### 7.1.2.7.11 Subscriber Certificate Key Usage
 
-The acceptable Key Usage values vary based on whether the Certificate's `subjectPublicKeyInfo` identifies an RSA public key or an ECC public key. CAs MUST ensure the Key Usage is appropriate for the Certificate Public Key.
+The acceptable Key Usage values vary based on whether the Certificate's `subjectPublicKeyInfo` identifies an RSA public key, an ECC public key, or an ML-DSA public key. CAs MUST ensure the Key Usage is appropriate for the Certificate Public Key.
 
 Table: Key Usage for RSA Public Keys
 
@@ -2900,6 +2907,20 @@ Table: Key Usage for ECC Public Keys
 | `decipherOnly`     | N             | --               |
 
 **Note**: The `keyAgreement` bit is currently permitted, although setting it is NOT RECOMMENDED, as it is a Pending Prohibition (<https://github.com/cabforum/servercert/issues/384>).
+
+Table: Key Usage for ML-DSA Public Keys
+
+| **Key Usage**      | **Permitted** | **Required**     |
+| -----              | --            | ---              |
+| `digitalSignature` | Y             | MUST             |
+| `nonRepudiation`   | N             | --               |
+| `keyEncipherment`  | N             | --               |
+| `dataEncipherment` | N             | --               |
+| `keyAgreement`     | N             | --               |
+| `keyCertSign`      | N             | --               |
+| `cRLSign`          | N             | --               |
+| `encipherOnly`     | N             | --               |
+| `decipherOnly`     | N             | --               |
 
 ##### 7.1.2.7.12 Subscriber Certificate Subject Alternative Name
 
@@ -3379,6 +3400,18 @@ When encoded, the `AlgorithmIdentifier` for ECDSA keys MUST be byte-for-byte ide
 - For P-384 keys, `301006072a8648ce3d020106052b81040022`.
 - For P-521 keys, `301006072a8648ce3d020106052b81040023`.
 
+##### 7.1.3.1.3 ML-DSA
+
+The CA SHALL indicate an ML-DSA key using the following algorithm identifier:
+
+  * ML-DSA-87 (OID: 2.16.840.1.101.3.4.3.19).
+
+The parameters for ML-DSA keys SHALL be absent. The CA MUST NOT use HashML-DSA; only "pure" ML-DSA is permitted.
+
+When encoded, the AlgorithmIdentifier for ML-DSA keys SHALL be byte-for-byte identical with the following hex-encoded bytes:
+
+* For ML-DSA-87, `300b0609608648016503040313`.
+
 #### 7.1.3.2 Signature AlgorithmIdentifier
 
 All objects signed by a CA Private Key MUST conform to these requirements on the use of the `AlgorithmIdentifier` or `AlgorithmIdentifier`-derived type in the context of signatures.
@@ -3486,6 +3519,12 @@ If the signing key is P-256, the signature MUST use ECDSA with SHA-256. When enc
 If the signing key is P-384, the signature MUST use ECDSA with SHA-384. When encoded, the `AlgorithmIdentifier` MUST be byte-for-byte identical with the following hex-encoded bytes: `300a06082a8648ce3d040303`.
 
 If the signing key is P-521, the signature MUST use ECDSA with SHA-512. When encoded, the `AlgorithmIdentifier` MUST be byte-for-byte identical with the following hex-encoded bytes: `300a06082a8648ce3d040304`.
+
+##### 7.1.3.2.3 ML-DSA
+
+The CA SHALL use the appropriate signature algorithm and encoding based upon the signing key used.
+
+If the signing key is ML-DSA-87, the signature algorithm SHALL be id-ml-dsa-87 (OID: 2.16.840.1.101.3.4.3.19). When encoded, the `AlgorithmIdentifier` SHALL be byte-for-byte identical with the following hex-encoded bytes: `300b0609608648016503040313`.
 
 ### 7.1.4 Name Forms
 

--- a/docs/BR.md
+++ b/docs/BR.md
@@ -2063,8 +2063,7 @@ For ECDSA key pairs, the CA SHALL:
 
 For ML-DSA key pairs, the CA SHALL:
 
-- If the key pair is a CA Key Pair, ensure that the key uses the ML-DSA-87 (OID: 2.16.840.1.101.3.4.3.19) parameter set.
-- If the key pair is not a CA Key Pair, ensure that the key uses one of the following parameter sets:
+- Ensure that the key uses one of the following parameter sets:
   - ML-DSA-44 (OID: 2.16.840.1.101.3.4.3.17), or
   - ML-DSA-65 (OID: 2.16.840.1.101.3.4.3.18), or
   - ML-DSA-87 (OID: 2.16.840.1.101.3.4.3.19).
@@ -3411,8 +3410,6 @@ The CA SHALL indicate an ML-DSA key using one of the following algorithm identif
 - ML-DSA-65 (OID: 2.16.840.1.101.3.4.3.18), or
 - ML-DSA-87 (OID: 2.16.840.1.101.3.4.3.19).
 
-As described in [Section 6.1.5](#615-key-sizes), ML-DSA CA Key Pairs MUST use the ML-DSA-87 parameter set.
-
 The parameters for ML-DSA keys SHALL be absent. The CA MUST NOT use HashML-DSA; only "pure" ML-DSA is permitted.
 
 When encoded, the AlgorithmIdentifier for ML-DSA keys SHALL be byte-for-byte identical with the following hex-encoded bytes:
@@ -3532,6 +3529,10 @@ If the signing key is P-521, the signature MUST use ECDSA with SHA-512. When enc
 ##### 7.1.3.2.3 ML-DSA
 
 The CA SHALL use the appropriate signature algorithm and encoding based upon the signing key used.
+
+If the signing key is ML-DSA-44, the signature algorithm SHALL be id-ml-dsa-44 (OID: 2.16.840.1.101.3.4.3.17). When encoded, the `AlgorithmIdentifier` SHALL be byte-for-byte identical with the following hex-encoded bytes: `300b0609608648016503040311`.
+
+If the signing key is ML-DSA-65, the signature algorithm SHALL be id-ml-dsa-65 (OID: 2.16.840.1.101.3.4.3.18). When encoded, the `AlgorithmIdentifier` SHALL be byte-for-byte identical with the following hex-encoded bytes: `300b0609608648016503040312`.
 
 If the signing key is ML-DSA-87, the signature algorithm SHALL be id-ml-dsa-87 (OID: 2.16.840.1.101.3.4.3.19). When encoded, the `AlgorithmIdentifier` SHALL be byte-for-byte identical with the following hex-encoded bytes: `300b0609608648016503040313`.
 

--- a/docs/BR.md
+++ b/docs/BR.md
@@ -161,7 +161,7 @@ The following Certificate Policy identifiers are reserved for use by CAs to asse
 | 2.2.4 | SC096 | Carve-out for DNSSEC verification logging requirements                                  | 2026-01-14 | 2026-02-17 |
 | 2.2.5 | SC097 | Sunset all remaining use of SHA-1 signatures in Certificates and CRLs                   | 2026-02-24 | 2026-02-25 |
 | 2.2.6 | SC095 | Clean-up 2025                                                                           | 2026-02-27 | 2026-03-31 |
-| 2.2.X | SCXXX | Permit ML-DSA-87 public keys in Certificates                                            | 2026-XX-XX | 2026-XX-XX |
+| 2.2.X | SCXXX | Permit ML-DSA public keys in Certificates                                               | 2026-XX-XX | 2026-XX-XX |
 
 \* Effective Date and Additionally Relevant Compliance Date(s)
 
@@ -2064,7 +2064,11 @@ For ECDSA key pairs, the CA SHALL:
 
 For ML-DSA key pairs, the CA SHALL:
 
-- Ensure that the key uses the ML-DSA-87 (OID: 2.16.840.1.101.3.4.3.19) parameter set.
+- If the key pair is a CA Key Pair, ensure that the key uses the ML-DSA-87 (OID: 2.16.840.1.101.3.4.3.19) parameter set.
+- If the key pair is not a CA Key Pair, ensure that the key uses one of the following parameter sets:
+  - ML-DSA-44 (OID: 2.16.840.1.101.3.4.3.17), or
+  - ML-DSA-65 (OID: 2.16.840.1.101.3.4.3.18), or
+  - ML-DSA-87 (OID: 2.16.840.1.101.3.4.3.19).
 
 No other algorithms or key sizes are permitted.
 
@@ -3402,15 +3406,19 @@ When encoded, the `AlgorithmIdentifier` for ECDSA keys MUST be byte-for-byte ide
 
 ##### 7.1.3.1.3 ML-DSA
 
-The CA SHALL indicate an ML-DSA key using the following algorithm identifier:
+The CA SHALL indicate an ML-DSA key using one of the following algorithm identifiers below:
 
-  * ML-DSA-87 (OID: 2.16.840.1.101.3.4.3.19).
+- ML-DSA-44 (OID: 2.16.840.1.101.3.4.3.17), or
+- ML-DSA-65 (OID: 2.16.840.1.101.3.4.3.18), or
+- ML-DSA-87 (OID: 2.16.840.1.101.3.4.3.19).
 
 The parameters for ML-DSA keys SHALL be absent. The CA MUST NOT use HashML-DSA; only "pure" ML-DSA is permitted.
 
 When encoded, the AlgorithmIdentifier for ML-DSA keys SHALL be byte-for-byte identical with the following hex-encoded bytes:
 
-* For ML-DSA-87, `300b0609608648016503040313`.
+- For ML-DSA-44, `300b0609608648016503040311`.
+- For ML-DSA-65, `300b0609608648016503040312`.
+- For ML-DSA-87, `300b0609608648016503040313`.
 
 #### 7.1.3.2 Signature AlgorithmIdentifier
 
@@ -3523,6 +3531,10 @@ If the signing key is P-521, the signature MUST use ECDSA with SHA-512. When enc
 ##### 7.1.3.2.3 ML-DSA
 
 The CA SHALL use the appropriate signature algorithm and encoding based upon the signing key used.
+
+If the signing key is ML-DSA-44, the signature algorithm SHALL be id-ml-dsa-44 (OID: 2.16.840.1.101.3.4.3.17). When encoded, the `AlgorithmIdentifier` SHALL be byte-for-byte identical with the following hex-encoded bytes: `300b0609608648016503040311`.
+
+If the signing key is ML-DSA-65, the signature algorithm SHALL be id-ml-dsa-65 (OID: 2.16.840.1.101.3.4.3.18). When encoded, the `AlgorithmIdentifier` SHALL be byte-for-byte identical with the following hex-encoded bytes: `300b0609608648016503040312`.
 
 If the signing key is ML-DSA-87, the signature algorithm SHALL be id-ml-dsa-87 (OID: 2.16.840.1.101.3.4.3.19). When encoded, the `AlgorithmIdentifier` SHALL be byte-for-byte identical with the following hex-encoded bytes: `300b0609608648016503040313`.
 

--- a/docs/BR.md
+++ b/docs/BR.md
@@ -1,11 +1,11 @@
 ---
 title: Baseline Requirements for the Issuance and Management of Publicly-Trusted TLS Server Certificates
 
-subtitle: Version 2.2.x
+subtitle: Version 2.2.6
 author:
   - CA/Browser Forum
 
-date: XX-XX-2026
+date: 31-March-2026
 
 copyright: |
   Copyright 2026 CA/Browser Forum
@@ -161,7 +161,6 @@ The following Certificate Policy identifiers are reserved for use by CAs to asse
 | 2.2.4 | SC096 | Carve-out for DNSSEC verification logging requirements                                  | 2026-01-14 | 2026-02-17 |
 | 2.2.5 | SC097 | Sunset all remaining use of SHA-1 signatures in Certificates and CRLs                   | 2026-02-24 | 2026-02-25 |
 | 2.2.6 | SC095 | Clean-up 2025                                                                           | 2026-02-27 | 2026-03-31 |
-| 2.2.X | SCXXX | Permit ML-DSA public keys and signatures in Certificates                                | 2026-XX-XX | 2026-XX-XX |
 
 \* Effective Date and Additionally Relevant Compliance Date(s)
 

--- a/docs/BR.md
+++ b/docs/BR.md
@@ -2099,7 +2099,6 @@ For ML-DSA key pairs, the CA SHALL:
 
 - Ensure that the key uses one of the following parameter sets:
   - ML-DSA-44 (OID: 2.16.840.1.101.3.4.3.17), or
-  - ML-DSA-65 (OID: 2.16.840.1.101.3.4.3.18), or
   - ML-DSA-87 (OID: 2.16.840.1.101.3.4.3.19).
 
 No other algorithms or key sizes are permitted.
@@ -3440,17 +3439,13 @@ When encoded, the `AlgorithmIdentifier` for ECDSA keys MUST be byte-for-byte ide
 
 The CA SHALL indicate an ML-DSA key using one of the following algorithm identifiers below:
 
-- ML-DSA-44 (OID: 2.16.840.1.101.3.4.3.17), or
-- ML-DSA-65 (OID: 2.16.840.1.101.3.4.3.18), or
-- ML-DSA-87 (OID: 2.16.840.1.101.3.4.3.19).
+- ML-DSA-44 (OID: 2.16.840.1.101.3.4.3.17).
 
-The parameters for ML-DSA keys SHALL be absent. The CA MUST NOT use HashML-DSA; only "pure" ML-DSA is permitted.
+The parameters for ML-DSA keys SHALL be absent. The CA MUST NOT use HashML-DSA; only "pure" ML-DSA is permitted. Additionally, the CA SHALL NOT use this algorithm if the algorithm identifier of the Certificate's signature algorithm is not ML-DSA-87 (OID: 2.16.840.1.101.3.4.3.19) or ML-DSA-44 (OID: 2.16.840.1.101.3.4.3.17).
 
 When encoded, the AlgorithmIdentifier for ML-DSA keys SHALL be byte-for-byte identical with the following hex-encoded bytes:
 
 - For ML-DSA-44, `300b0609608648016503040311`.
-- For ML-DSA-65, `300b0609608648016503040312`.
-- For ML-DSA-87, `300b0609608648016503040313`.
 
 #### 7.1.3.2 Signature AlgorithmIdentifier
 
@@ -3562,11 +3557,9 @@ If the signing key is P-521, the signature MUST use ECDSA with SHA-512. When enc
 
 ##### 7.1.3.2.3 ML-DSA
 
-The CA SHALL use the appropriate signature algorithm and encoding based upon the signing key used.
+The CA SHALL use the appropriate signature algorithm and encoding based upon the signing key used. Additionally, the CA SHALL NOT use this signature algorithm if the algorithm identifier of the public key being certified is not id-ml-dsa-44 (OID: 2.16.840.1.101.3.4.3.17).
 
 If the signing key is ML-DSA-44, the signature algorithm SHALL be id-ml-dsa-44 (OID: 2.16.840.1.101.3.4.3.17). When encoded, the `AlgorithmIdentifier` SHALL be byte-for-byte identical with the following hex-encoded bytes: `300b0609608648016503040311`.
-
-If the signing key is ML-DSA-65, the signature algorithm SHALL be id-ml-dsa-65 (OID: 2.16.840.1.101.3.4.3.18). When encoded, the `AlgorithmIdentifier` SHALL be byte-for-byte identical with the following hex-encoded bytes: `300b0609608648016503040312`.
 
 If the signing key is ML-DSA-87, the signature algorithm SHALL be id-ml-dsa-87 (OID: 2.16.840.1.101.3.4.3.19). When encoded, the `AlgorithmIdentifier` SHALL be byte-for-byte identical with the following hex-encoded bytes: `300b0609608648016503040313`.
 


### PR DESCRIPTION
Currently the BRs require the use of RSA or ECDSA keys and signatures. This ballot allows ML-DSA-{44,65,87} as well.

Based on [SMC013](https://github.com/cabforum/smime/pull/284) by @srdavidson.
